### PR TITLE
show the oauth scope for the api's that use fabric read scope

### DIFF
--- a/Fabric.Identity.API/Authorization/IHaveAuthorizationClaimType.cs
+++ b/Fabric.Identity.API/Authorization/IHaveAuthorizationClaimType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fabric.Identity.API.Authorization
+{
+    public interface IHaveAuthorizationClaimType
+    {
+        string ClaimType { get; }
+    }
+}

--- a/Fabric.Identity.API/Authorization/ReadAuthorizationHandler.cs
+++ b/Fabric.Identity.API/Authorization/ReadAuthorizationHandler.cs
@@ -24,9 +24,9 @@ namespace Fabric.Identity.API.Authorization
         {
             //ensure the logged in client has the read scope claim
 
-            if (HasRequiredScopeClaim(context.User, requirement.ReadScope))
+            if (HasRequiredScopeClaim(context.User, requirement.ClaimType))
             {
-                _logger.Information($"User has required scope claim: {requirement.ReadScope}, authorization succeeded.");
+                _logger.Information($"User has required scope claim: {requirement.ClaimType}, authorization succeeded.");
                 context.Succeed(requirement);                
             }
 

--- a/Fabric.Identity.API/Authorization/ReadScopeRequirement.cs
+++ b/Fabric.Identity.API/Authorization/ReadScopeRequirement.cs
@@ -7,8 +7,8 @@ using Microsoft.Extensions.Primitives;
 
 namespace Fabric.Identity.API.Authorization
 {
-    public class ReadScopeRequirement : IAuthorizationRequirement
+    public class ReadScopeRequirement : IAuthorizationRequirement, IHaveAuthorizationClaimType
     {
-        public string ReadScope { get; } = FabricIdentityConstants.IdentityReadScope;
+        public string ClaimType { get; } = FabricIdentityConstants.IdentityReadScope;
     }
 }

--- a/Fabric.Identity.API/Authorization/RegisteredClientThresholdRequirement.cs
+++ b/Fabric.Identity.API/Authorization/RegisteredClientThresholdRequirement.cs
@@ -2,7 +2,7 @@
 
 namespace Fabric.Identity.API.Authorization
 {
-    public class RegisteredClientThresholdRequirement : IAuthorizationRequirement
+    public class RegisteredClientThresholdRequirement : IAuthorizationRequirement, IHaveAuthorizationClaimType
     {
         public int RegisteredClientThreshold { get; }
 

--- a/Fabric.Identity.API/Documentation/SecurityRequirementsOperationFilter.cs
+++ b/Fabric.Identity.API/Documentation/SecurityRequirementsOperationFilter.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Fabric.Identity.API.Authorization;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -31,8 +28,8 @@ namespace Fabric.Identity.API.Documentation
             var policies = controllerPolicies.Union(actionPolicies).Distinct();
             var requiredClaimTypes = policies
                 .Select(x => authorizationOptions.Value.GetPolicy(x))
-                .SelectMany(x => x.Requirements)
-                .OfType<RegisteredClientThresholdRequirement>()
+                .SelectMany(x => x.Requirements)               
+                .OfType<IHaveAuthorizationClaimType>()
                 .Select(x => x.ClaimType);
 
             if (requiredClaimTypes.Any())


### PR DESCRIPTION
currently on the users api uses the fabric read scope

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/37)
<!-- Reviewable:end -->
