### PR TITLE
Updated installation script to move parameters to configuration.

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -13,16 +13,68 @@ param(
 	[String]$appInsightsInstrumentationKey,
 	[String]$siteName = "Default Web Site",
 	[String]$hostUrl)
+	
+function Test-RegistrationComplete($authUrl)
+{
+    $url = "$authUrl/api/client/fabric-installer"
+    $headers = @{"Accept" = "application/json"}
+    
+    try {
+        Invoke-RestMethod -Method Get -Uri $url -Headers $headers
+    } catch {
+        $exception = $_.Exception
+    }
 
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -OutFile Fabric-Install-Utilities.psm1
-Import-Module -Name .\Fabric-Install-Utilities.psm1 -Verbose
+    if($exception -ne $null -and $exception.Response.StatusCode.value__ -eq 401)
+    {
+        Write-Host "Fabric registration is already complete."
+        return $true
+    }
+
+    return $false
+}
+
+$workingDirectory = Split-Path $script:MyInvocation.MyCommand.Path
+if(!(Test-Path $workingDirectory\Fabric-Install-Utilities.psm1)){
+	Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -OutFile Fabric-Install-Utilities.psm1
+}
+Import-Module -Name .\Fabric-Install-Utilities.psm1
+
+if(!(Test-Prerequisite '*.NET Core*Windows Server Hosting*' 1.1.30327.81))
+{
+    Write-Host ".NET Core Windows Server Hosting Bundle minimum version 1.1.30327.81 not installed...download and install from https://go.microsoft.com/fwlink/?linkid=844461. Halting installation."
+    exit 1
+}else{
+    Write-Host ".NET Core Windows Server Hosting Bundle installed and meets expectations."
+}
+
+if(!(Test-Prerequisite '*CouchDB*'))
+{
+    Write-Host "CouchDB not installed locally, testing to see if is installed on a remote server using $couchDbServer"
+    $remoteInstallationStatus = Get-CouchDbRemoteInstallationStatus $couchDbServer 2.0.0
+    if($remoteInstallationStatus -eq "NotInstalled")
+    {
+        Write-Host "CouchDB not installed, download and install from https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi. Halting installation."
+		exit 1
+    }elseif($remoteInstallationStatus -eq "MinVersionNotMet"){
+        Write-Host "CouchDB is installed on $couchDbServer but does not meet the minimum version requirements, you must have CouchDB 2.0.0.1 or greater installed: https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi. Halting installation."
+        exit 1
+    }else{
+        Write-Host "CouchDB installed and meets specifications"
+    }
+}elseif (!(Test-Prerequisite '*CouchDB*' 2.0.0.1)) {
+    Write-Host "CouchDB is installed but does not meet the minimum version requirements, you must have CouchDB 2.0.0.1 or greater installed: https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi. Halting installation."
+    exit 1
+}else{
+    Write-Host "CouchDB installed and meets specifications"
+}
 
 $appDirectory = "$webroot\$appName"
 New-AppRoot $appDirectory $iisUser
 Write-Host "App directory is: $appDirectory"
 New-AppPool $appName
 New-App $appName $siteName $appDirectory
-Publish-WebSite $zipPackage $appDirectory
+Publish-WebSite $zipPackage $appDirectory $appName
 
 
 #Write environment variables
@@ -60,3 +112,48 @@ if($appInsightsInstrumentationKey){
 $environmentVariables.Add("IdentityServerConfidentialClientSettings__Authority", "${hostUrl}/${appName}")
 
 Set-EnvironmentVariables $appDirectory $environmentVariables
+
+Set-Location $workingDirectory
+$identityServerUrl = "$hostUrl/identity"
+
+if(Test-RegistrationComplete $identityServerUrl)
+{
+    Write-Host "Installation complete, exiting."
+    exit 0
+}
+
+#Register registration api
+$body = @'
+{
+    "name":"registration-api",
+    "userClaims":["name","email","role","groups"],
+    "scopes":[{"name":"fabric/identity.manageresources"}]
+}
+'@
+
+Write-Host "Registering Fabric.Identity registration api."
+$registrationApiSecret = Add-ApiRegistration -authUrl $identityServerUrl -body $body
+
+#Register Fabric.Installer
+$body = @'
+{
+    "clientId":"fabric-installer", 
+    "clientName":"Fabric Installer", 
+    "requireConsent":"false", 
+    "allowedGrantTypes": ["client_credentials"], 
+    "allowedScopes": ["fabric/identity.manageresources", "fabric/authorization.read", "fabric/authorization.write", "fabric/authorization.manageclients"]
+}
+'@
+
+Write-Host "Registering Fabric.Installer."
+$installerClientSecret = Add-ClientRegistration -authUrl $identityServerUrl -body $body
+
+Write-Host ""
+Write-Host "Please keep the following secrets in a secure place:"
+Write-Host "Fabric.Installer clientSecret: $installerClientSecret"
+Write-Host "Fabric.Registration apiSecret: $registrationApiSecret"
+Write-Host ""
+Write-Host "The Fabric.Installer clientSecret will be needed in subsequent installations:"
+Write-Host "Fabric.Installer clientSecret: $installerClientSecret"
+
+Write-Host "Installation complete, exiting."

--- a/Fabric.Identity.API/scripts/install.config
+++ b/Fabric.Identity.API/scripts/install.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<installation>
+    <settings>
+      <scope name="common">
+        <variable name="fabricInstallerSecret" value="" />
+      </scope>
+      <scope name="identity">
+        <variable name="zipPackage" value="Fabric.Identity.API.zip" />
+        <variable name="webRoot" value="C:\inetpub\wwwroot" />
+        <variable name="appName" value="identity" />
+        <variable name="iisUser" value="IIS_IUSRS" />
+        <variable name="sslCertificateThumbprint" value="" />
+        <variable name="couchDbServer" value="http://127.0.0.1:5984" />
+        <variable name="couchDbUsername" value="" />
+        <variable name="couchDbPassword" value="" />
+        <variable name="appInsightsInstrumentationKey" value="" />
+        <variable name="siteName" value="Default Web Site" />
+        <variable name="hostUrl" value="http://localhost" />
+      </scope>
+    </settings>  
+</installation>

--- a/Fabric.Identity.API/scripts/install.config
+++ b/Fabric.Identity.API/scripts/install.config
@@ -1,21 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <installation>
-    <settings>
-      <scope name="common">
-        <variable name="fabricInstallerSecret" value="" />
-      </scope>
-      <scope name="identity">
-        <variable name="zipPackage" value="Fabric.Identity.API.zip" />
-        <variable name="webRoot" value="C:\inetpub\wwwroot" />
-        <variable name="appName" value="identity" />
-        <variable name="iisUser" value="IIS_IUSRS" />
-        <variable name="sslCertificateThumbprint" value="" />
-        <variable name="couchDbServer" value="http://127.0.0.1:5984" />
-        <variable name="couchDbUsername" value="" />
-        <variable name="couchDbPassword" value="" />
-        <variable name="appInsightsInstrumentationKey" value="" />
-        <variable name="siteName" value="Default Web Site" />
-        <variable name="hostUrl" value="http://localhost" />
-      </scope>
-    </settings>  
+  <settings>
+    <scope name="common">
+      <variable name="fabricInstallerSecret" value="" />
+      <variable name="encryptionCertificateThumbprint" value="" />
+    </scope>
+    <scope name="identity">
+      <variable name="zipPackage" value="Fabric.Identity.API.zip" />
+      <variable name="webRoot" value="C:\inetpub\wwwroot" />
+      <variable name="appName" value="identity" />
+      <variable name="iisUser" value="IIS_IUSRS" />
+      <variable name="sslCertificateThumbprint" value="" />
+      <variable name="couchDbServer" value="http://127.0.0.1:5984" />
+      <variable name="couchDbUsername" value="" />
+      <variable name="couchDbPassword" value="" />
+      <variable name="appInsightsInstrumentationKey" value="" />
+      <variable name="siteName" value="Default Web Site" />
+      <variable name="hostUrl" value="http://localhost" />
+    </scope>
+  </settings>
 </installation>


### PR DESCRIPTION
This will allow us to simply edit the config parameters in a file, and call the installation script without passing parameters. We also allow pushing a new variable to the config (with an option to encrypt) so it can be used downstream.

This pull request also encompasses moving prerequisite tests and registration steps to the identity install script.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/38)
<!-- Reviewable:end -->
