### PR TITLE
Split Encryption and Signing cert

### DIFF
--- a/Fabric.Identity.API/Configuration/IdentityConfigurationProvider.cs
+++ b/Fabric.Identity.API/Configuration/IdentityConfigurationProvider.cs
@@ -59,7 +59,7 @@ namespace Fabric.Identity.API.Configuration
         private string DecryptString(string encryptedString, ICertificateService certificateService, IAppConfiguration appConfiguration)
         {
 
-            var cert = certificateService.GetCertificate(appConfiguration.SigningCertificateSettings);
+            var cert = certificateService.GetEncryptionCertificate(appConfiguration.SigningCertificateSettings);
             var encryptedPasswordAsBytes =
                 System.Convert.FromBase64String(
                     encryptedString.TrimStart(EncryptionPrefix.ToCharArray()));

--- a/Fabric.Identity.API/Configuration/SigningCertificateSettings.cs
+++ b/Fabric.Identity.API/Configuration/SigningCertificateSettings.cs
@@ -5,6 +5,7 @@
         public bool UseTemporarySigningCredential { get; set; }
         public string PrimaryCertificateThumbprint { get; set; }
         public string SecondaryCertificateThumbprint { get; set; }
+        public string EncryptionCertificateThumbprint { get; set; }
         public string PrimaryCertificatePath { get; set; }
         public string SecondaryCertificatePath { get; set; }
         public string PrimaryCertificatePasswordPath { get; set; }

--- a/Fabric.Identity.API/Extensions/IdentityServerBuilderExtensions.cs
+++ b/Fabric.Identity.API/Extensions/IdentityServerBuilderExtensions.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Fabric.Identity.API.Configuration;
 using Fabric.Identity.API.Services;
 using IdentityServer4.Quickstart.UI;
-using IdentityServer4.Test;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
@@ -34,11 +32,11 @@ namespace Fabric.Identity.API.Extensions
 
             var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
-            identityServerBuilder.AddSigningCredential(certificateService.GetCertificate(certificateSettings));
+            identityServerBuilder.AddSigningCredential(certificateService.GetSigningCertificate(certificateSettings));
             if (HasSecondarySigningKeys(certificateSettings, isLinux))
             {
                 identityServerBuilder.AddValidationKeys(
-                    new X509SecurityKey(certificateService.GetCertificate(certificateSettings, isPrimary: false)));
+                    new X509SecurityKey(certificateService.GetSigningCertificate(certificateSettings, isPrimary: false)));
             }
 
             return identityServerBuilder;

--- a/Fabric.Identity.API/Services/ICertificateService.cs
+++ b/Fabric.Identity.API/Services/ICertificateService.cs
@@ -10,5 +10,6 @@ namespace Fabric.Identity.API.Services
     public interface ICertificateService
     {
         X509Certificate2 GetCertificate(SigningCertificateSettings certificateSettings, bool isPrimary = true);
+        X509Certificate2 GetEncryptionCertificate(SigningCertificateSettings certificateSettings);
     }
 }

--- a/Fabric.Identity.API/Services/ICertificateService.cs
+++ b/Fabric.Identity.API/Services/ICertificateService.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
+﻿using System.Security.Cryptography.X509Certificates;
 using Fabric.Identity.API.Configuration;
 
 namespace Fabric.Identity.API.Services
 {
     public interface ICertificateService
     {
-        X509Certificate2 GetCertificate(SigningCertificateSettings certificateSettings, bool isPrimary = true);
+        X509Certificate2 GetSigningCertificate(SigningCertificateSettings certificateSettings, bool isPrimary = true);
         X509Certificate2 GetEncryptionCertificate(SigningCertificateSettings certificateSettings);
     }
 }

--- a/Fabric.Identity.API/Services/LinuxCertificateService.cs
+++ b/Fabric.Identity.API/Services/LinuxCertificateService.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Fabric.Identity.API.Configuration;
 using Fabric.Platform.Shared.Exceptions;
 using RestSharp.Extensions;
-using Serilog;
 
 namespace Fabric.Identity.API.Services
 {
     public class LinuxCertificateService : ICertificateService
     {
-        public X509Certificate2 GetCertificate(SigningCertificateSettings certificateSettings, bool isPrimary)
+        public X509Certificate2 GetSigningCertificate(SigningCertificateSettings certificateSettings, bool isPrimary)
         {
             if (isPrimary && string.IsNullOrEmpty(certificateSettings.PrimaryCertificatePath))
             {

--- a/Fabric.Identity.API/Services/LinuxCertificateService.cs
+++ b/Fabric.Identity.API/Services/LinuxCertificateService.cs
@@ -37,6 +37,11 @@ namespace Fabric.Identity.API.Services
                     certificateSettings.SecondaryCertificatePasswordPath);
         }
 
+        public X509Certificate2 GetEncryptionCertificate(SigningCertificateSettings certificateSettings)
+        {
+            throw new FabricConfigurationException("Do not encrypt settings when running on a Linux container, instead use Docker Secrets to protect sensitive configuration settings.");
+        }
+
         private X509Certificate2 GetCertFromFile(string certPath, string passwordPath)
         {
             using (var certStream = new FileStream(certPath, FileMode.Open, FileAccess.Read))

--- a/Fabric.Identity.API/Services/WindowsCertificateService.cs
+++ b/Fabric.Identity.API/Services/WindowsCertificateService.cs
@@ -27,6 +27,17 @@ namespace Fabric.Identity.API.Services
             return X509.LocalMachine.My.Thumbprint.Find(thumbprint, validOnly: false).FirstOrDefault();
         }
 
+        public X509Certificate2 GetEncryptionCertificate(SigningCertificateSettings certificateSettings)
+        {
+            if (string.IsNullOrWhiteSpace(certificateSettings?.EncryptionCertificateThumbprint))
+            {
+                throw new FabricConfigurationException("You must specify an EncryptionCertificateThumprint if you are encrypting configuration settings.");
+            }
+            return X509.LocalMachine.My.Thumbprint
+                .Find(CleanThumbprint(certificateSettings.EncryptionCertificateThumbprint), false)
+                .FirstOrDefault();
+        }
+
         private string CleanThumbprint(string thumbprint)
         {
             

--- a/Fabric.Identity.API/Services/WindowsCertificateService.cs
+++ b/Fabric.Identity.API/Services/WindowsCertificateService.cs
@@ -1,18 +1,16 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Fabric.Identity.API.Configuration;
 using Fabric.Platform.Shared.Exceptions;
 using IdentityModel;
-using Serilog;
 
 namespace Fabric.Identity.API.Services
 {
     public class WindowsCertificateService : ICertificateService
     {
 
-        public X509Certificate2 GetCertificate(SigningCertificateSettings certificateSettings, bool isPrimary = true)
+        public X509Certificate2 GetSigningCertificate(SigningCertificateSettings certificateSettings, bool isPrimary = true)
         {
             if (isPrimary && string.IsNullOrEmpty(certificateSettings.PrimaryCertificateThumbprint))
             {

--- a/Fabric.Identity.API/appsettings.json
+++ b/Fabric.Identity.API/appsettings.json
@@ -8,6 +8,7 @@
     "UseTemporarySigningCredential": true,
     "PrimaryCertificateThumbprint": "",
     "SecondaryCertificateThumbprint": "",
+    "EncryptionCertificateThumbprint":  "", 
     "PrimaryCertificatePath": "",
     "SecondaryCertificatePath": "",
     "PrimaryCertificatePasswordPath": "",

--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -33,6 +33,7 @@ $webroot = $installSettings.webroot
 $appName = $installSettings.appName
 $iisUser = $installSettings.iisUser
 $primarySigningCertificateThumbprint = $installSettings.primarySigningCertificateThumbprint -replace '[^a-zA-Z0-9]', ''
+$encryptionCertificateThumbprint = $installSettings.encryptionCertificateThumbprint -replace '[^a-zA-Z0-9]', ''
 $couchDbServer = $installSettings.couchDbServer
 $couchDbUsername = $installSettings.couchDbUsername
 $couchDbPassword = $installSettings.couchDbPassword 
@@ -52,6 +53,13 @@ try{
 	$signingCert = Get-Certificate $primarySigningCertificateThumbprint
 }catch{
 	Write-Host "Could not get signing certificate with thumbprint $primarySigningCertificateThumbprint. Please verify that the primarySigningCertificateThumbprint setting in install.config contains a valid thumbprint for a certificate in the Local Machine Personal store."
+	throw $_.Exception
+}
+
+try{
+	$encryptionCert = Get-Certificate $encryptionCertificateThumbprint
+}catch{
+	Write-Host "Could not get encryption certificate with thumbprint $encryptionCertificateThumbprint. Please verify that the encryptionCertificateThumbprint setting in install.config contains a valid thumbprint for a certificate in the Local Machine Personal store."
 	throw $_.Exception
 }
 
@@ -120,6 +128,10 @@ if ($primarySigningCertificateThumbprint){
 	$environmentVariables.Add("SigningCertificateSettings__PrimaryCertificateThumbprint", $primarySigningCertificateThumbprint)
 }
 
+if ($encryptionCertificateThumbprint){
+	$environmentVariables.Add("SigningCertificateSettings__EncryptionCertificateThumbprint", $encryptionCertificateThumbprint)
+}
+
 if ($couchDbServer){
 	$environmentVariables.Add("CouchDbSettings__Server", $couchDbServer)
 }
@@ -129,7 +141,7 @@ if ($couchDbUsername){
 }
 
 if ($couchDbPassword){
-	$encryptedCouchDbPassword = Get-EncryptedString $signingCert $couchDbPassword
+	$encryptedCouchDbPassword = Get-EncryptedString $encryptionCert $couchDbPassword
 	$environmentVariables.Add("CouchDbSettings__Password", $encryptedCouchDbPassword)
 }
 
@@ -153,7 +165,7 @@ if($ldapUserName){
 }
 
 if($ldapPassword){
-	$encryptedLdapPassword = Get-EncryptedString $signingCert $ldapPassword
+	$encryptedLdapPassword = Get-EncryptedString $encryptionCert $ldapPassword
 	$environmentVariables.Add("LdapSettings__Password", $encryptedLdapPassword)
 }
 

--- a/Fabric.Identity.API/scripts/install.config
+++ b/Fabric.Identity.API/scripts/install.config
@@ -18,6 +18,8 @@
       <variable name="iisUser" value="IIS_IUSRS" />
       <!-- The thumbprint of an SSL certificate to use for signing access and identity tokens -->
       <variable name="primarySigningCertificateThumbprint" value="" />
+      <!-- The thumbprint of an SSL certificate to use for encrypting/decrypting sensitive information in the config -->
+      <variable name="encryptionCertificateThumbprint" value="" />
       <!-- The URL:port of the CouchDB server -->
       <variable name="couchDbServer" value="http://127.0.0.1:5984" />
       <!-- The username for the CouchDb server -->

--- a/Fabric.Identity.UnitTests/LinuxCertificateServiceTests.cs
+++ b/Fabric.Identity.UnitTests/LinuxCertificateServiceTests.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using Fabric.Identity.API.Configuration;
 using Fabric.Identity.API.Services;
 using Fabric.Platform.Shared.Exceptions;
-using Moq;
-using Serilog;
 using Xunit;
 
 namespace Fabric.Identity.UnitTests
@@ -18,14 +14,22 @@ namespace Fabric.Identity.UnitTests
         public void GetCertificate_WithoutCertPath_ThrowsFabricConfigurationException(SigningCertificateSettings signingCertificateSettings, bool isPrimary)
         {
             var certificateService = new LinuxCertificateService();
-            Assert.Throws<FabricConfigurationException>(() => certificateService.GetCertificate(signingCertificateSettings, isPrimary));
+            Assert.Throws<FabricConfigurationException>(() => certificateService.GetSigningCertificate(signingCertificateSettings, isPrimary));
         }
 
         [Theory, MemberData(nameof(SigningCredentialSettingsNotFoundException))]
         public void GetCertificate_WithoutCertPath_ThrowsFileNotFoundException(SigningCertificateSettings signingCertificateSettings, bool isPrimary)
         {
             var certificateService = new LinuxCertificateService();
-            Assert.Throws<FileNotFoundException>(() => certificateService.GetCertificate(signingCertificateSettings, isPrimary));
+            Assert.Throws<FileNotFoundException>(() => certificateService.GetSigningCertificate(signingCertificateSettings, isPrimary));
+        }
+
+        [Fact]
+        public void GetEncryptionCertificate_ThrowsFabricConfigurationException()
+        {
+            var certificateService = new LinuxCertificateService();
+            Assert.Throws<FabricConfigurationException>(
+                () => certificateService.GetEncryptionCertificate(new SigningCertificateSettings()));
         }
 
         public static IEnumerable<object[]> SigningCredentialSettingsConfigurationException => new[]

--- a/Fabric.Identity.UnitTests/UserLoginManagerTests.cs
+++ b/Fabric.Identity.UnitTests/UserLoginManagerTests.cs
@@ -25,12 +25,12 @@ namespace Fabric.Identity.UnitTests
                 new DocumentDbUserStore(new InMemoryDocumentService(), new Mock<ILogger>().Object),
                 new Mock<ILogger>().Object);
 
-            var userId = "HealthCatalyst\\foo.bar";
+            var userId = "HealthCatalyst\\foo.baz";
             var provider = FabricIdentityConstants.FabricExternalIdentityProviderTypes.Windows;
             var clientId = "sampleApp";
-            var userName = "foo bar";
+            var userName = "foo baz";
             var firstName = "foo";
-            var lastName = "bar";
+            var lastName = "baz";
             var middleName = "dot";
             var claims = new List<Claim>
             {

--- a/Fabric.Identity.UnitTests/WindowsCertificateServiceTests.cs
+++ b/Fabric.Identity.UnitTests/WindowsCertificateServiceTests.cs
@@ -1,11 +1,7 @@
 ﻿using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using Fabric.Identity.API.Configuration;
 using Fabric.Identity.API.Services;
 using Fabric.Platform.Shared.Exceptions;
-using IdentityModel;
-using Moq;
-using Serilog;
 using Xunit;
 
 namespace Fabric.Identity.UnitTests
@@ -17,7 +13,7 @@ namespace Fabric.Identity.UnitTests
         public void GetCertificate_WithoutThumbprint_ThrowsException(SigningCertificateSettings signingCertificateSettings, bool isPrimary)
         {
             var certificateService = new WindowsCertificateService();
-            Assert.Throws<FabricConfigurationException>(() => certificateService.GetCertificate(signingCertificateSettings, isPrimary));
+            Assert.Throws<FabricConfigurationException>(() => certificateService.GetSigningCertificate(signingCertificateSettings, isPrimary));
         }
 
         public static IEnumerable<object[]> SigningCredentialSettings => new[]


### PR DESCRIPTION
Allow defining both an encryption and signing certificate so that the signing certificate can be rotated without breaking the encryption of configuration items in the web.config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/55)
<!-- Reviewable:end -->
