### PR TITLE
Add a user in CouchDbBootstrapper.

### DIFF
--- a/Fabric.Identity.API/CouchDb/DocumentDbBootstrapper.cs
+++ b/Fabric.Identity.API/CouchDb/DocumentDbBootstrapper.cs
@@ -3,7 +3,6 @@ using Fabric.Identity.API.Services;
 
 namespace Fabric.Identity.API.CouchDb
 {
-    [System.Obsolete]
     public class DocumentDbBootstrapper
     {
         protected readonly IDocumentDbService DocumentDbService;


### PR DESCRIPTION
While we have an administrator user for the overall CouchDb instance, if we don't have a user defined in the individual database, the database itself is public and authentication is not required to make updates to the data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/70)
<!-- Reviewable:end -->
