### PR TITLE
Added the ability to degrade gracefully if we cannot connect to ldap …

### DIFF
--- a/Fabric.Identity.API/Exceptions/InvalidExternalIdentityProviderException.cs
+++ b/Fabric.Identity.API/Exceptions/InvalidExternalIdentityProviderException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fabric.Identity.API.Exceptions
+{
+    public class InvalidExternalIdentityProviderException : Exception
+    {
+        public InvalidExternalIdentityProviderException()
+        {
+        }
+
+        public InvalidExternalIdentityProviderException(string message) : base(message)
+        {
+        }
+
+        public InvalidExternalIdentityProviderException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Fabric.Identity.API/Infrastructure/PolicyProvider.cs
+++ b/Fabric.Identity.API/Infrastructure/PolicyProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Novell.Directory.Ldap;
+using Polly;
+using Polly.CircuitBreaker;
+
+namespace Fabric.Identity.API.Infrastructure
+{
+    public class PolicyProvider
+    {
+        public readonly CircuitBreakerPolicy LdapErrorPolicy = Policy.Handle<LdapException>()
+            .CircuitBreaker(5, TimeSpan.FromMinutes(5));
+    }
+}

--- a/Fabric.Identity.API/Management/UsersController.cs
+++ b/Fabric.Identity.API/Management/UsersController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Fabric.Identity.API.Exceptions;
 using Fabric.Identity.API.Models;
 using Fabric.Identity.API.Infrastructure.QueryStringBinding;
 using Fabric.Identity.API.Services;
@@ -88,7 +89,7 @@ namespace Fabric.Identity.API.Management
                 });
                 return Ok(apiUsers);
             }
-            catch (InvalidOperationException e)
+            catch (InvalidExternalIdentityProviderException e)
             {
                 return CreateFailureResponse(e.Message, HttpStatusCode.BadRequest);
             }

--- a/Fabric.Identity.API/Services/ExternalIdentityProviderServiceResolver.cs
+++ b/Fabric.Identity.API/Services/ExternalIdentityProviderServiceResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Fabric.Identity.API.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Fabric.Identity.API.Services
@@ -17,7 +18,8 @@ namespace Fabric.Identity.API.Services
                 case FabricIdentityConstants.FabricExternalIdentityProviderTypes.Windows:
                     return _serviceProvider.GetRequiredService<LdapProviderService>();
                 default:
-                    throw new InvalidOperationException($"There is no search provider specified for the requested Identity Provider: {identityProviderName}.");
+                    throw new InvalidExternalIdentityProviderException(
+                        $"There is no search provider specified for the requested Identity Provider: {identityProviderName}.");
             }
         }
     }

--- a/Fabric.Identity.API/Startup.cs
+++ b/Fabric.Identity.API/Startup.cs
@@ -75,6 +75,7 @@ namespace Fabric.Identity.API
             services.AddSingleton<ILdapConnectionProvider, LdapConnectionProvider>();
             services.AddSingleton<IExternalIdentityProviderServiceResolver, ExternalIdentityProviderServiceResolver>();
             services.AddSingleton<LdapProviderService>();
+            services.AddSingleton<PolicyProvider>();
 
             // filter settings
             var filterSettings = _appConfig.FilterSettings ??


### PR DESCRIPTION
…for any reason.

We're handling the LdapException when connecting and searching, In addition, i've added a circuit breaker in to stop processing search requests for 5 minutes if we can't connect to ldap on 5 consecutive attempts, which will help us be more resilient to external service failures/timeouts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/71)
<!-- Reviewable:end -->
