### PR TITLE
User/mvidal/refactor integration tests

### DIFF
--- a/Fabric.Identity.API/Configuration/HostingOptions.cs
+++ b/Fabric.Identity.API/Configuration/HostingOptions.cs
@@ -3,8 +3,7 @@
     public class HostingOptions
     {
         public bool UseIis { get; set; }
-        public bool UseInMemoryStores { get; set; }
-
         public bool UseTestUsers { get; set; }
+        public string StorageProvider { get; set; }
     }
 }

--- a/Fabric.Identity.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Fabric.Identity.API/Extensions/ServiceCollectionExtensions.cs
@@ -149,7 +149,8 @@ namespace Fabric.Identity.API.Extensions
         {
             serviceCollection.AddSingleton<IProfileService, UserProfileService>();
 
-            if (hostingOptions.UseInMemoryStores)
+            if (string.Equals(hostingOptions.StorageProvider,
+                FabricIdentityConstants.StorageProviders.InMemory, StringComparison.OrdinalIgnoreCase))
             {
                 serviceCollection.AddInMemoryIdentityServer(appConfiguration);
             }

--- a/Fabric.Identity.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Fabric.Identity.API/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ namespace Fabric.Identity.API.Extensions
             ILogger logger)
         {
             serviceCollection.AddSingleton<IDocumentDbService, CouchDbAccessService>();
+            serviceCollection.AddScopedDecorator<IDocumentDbService, AuditingDocumentDbService>();
             serviceCollection.AddTransient<IClientManagementStore, CouchDbClientStore>();
             serviceCollection.AddTransient<IApiResourceStore, CouchDbApiResourceStore>();
             serviceCollection.AddTransient<IIdentityResourceStore, CouchDbIdentityResourceStore>();

--- a/Fabric.Identity.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Fabric.Identity.API/Extensions/ServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ namespace Fabric.Identity.API.Extensions
             serviceCollection.AddTransient<IUserStore, CouchDbUserStore>();
             serviceCollection.AddTransient<IDbBootstrapper, CouchDbBootstrapper>();
 
-            serviceCollection.AddSingleton(couchDbSettings);
+            serviceCollection.TryAddSingleton(couchDbSettings);
 
             serviceCollection.AddTransient<ICorsPolicyProvider, FabricCorsPolicyProvider>();
 
@@ -145,11 +145,11 @@ namespace Fabric.Identity.API.Extensions
         }
 
         public static IServiceCollection AddIdentityServer(this IServiceCollection serviceCollection,
-            IAppConfiguration appConfiguration, ICertificateService certificateService, ILogger logger)
+            IAppConfiguration appConfiguration, ICertificateService certificateService, ILogger logger, HostingOptions hostingOptions)
         {
             serviceCollection.AddSingleton<IProfileService, UserProfileService>();
 
-            if (appConfiguration.HostingOptions.UseInMemoryStores)
+            if (hostingOptions.UseInMemoryStores)
             {
                 serviceCollection.AddInMemoryIdentityServer(appConfiguration);
             }

--- a/Fabric.Identity.API/FabricIdentityConstants.cs
+++ b/Fabric.Identity.API/FabricIdentityConstants.cs
@@ -10,6 +10,13 @@
         public static readonly string IdentitySearchUsersScope = "fabric/identity.searchusers";
         public static readonly string AuditEventCategory = "Audit";
 
+        public static class StorageProviders
+        {
+            public const string InMemory = "inmemory";
+            public const string CouchDb = "couchdb";
+            public const string SqlServer = "sqlserver";
+        }
+
         public static class DocumentTypes
         {
             public static readonly string IdentityResourceDocumentType = "identityresource:";

--- a/Fabric.Identity.API/FabricIdentityEnums.cs
+++ b/Fabric.Identity.API/FabricIdentityEnums.cs
@@ -7,5 +7,12 @@
             Duplicate,
             MissingRequiredField            
         }
+
+        public enum StoreOptions
+        {
+            InMemory,
+            CouchDb,
+            SqlServer
+        }
     }
 }

--- a/Fabric.Identity.API/FabricIdentityEnums.cs
+++ b/Fabric.Identity.API/FabricIdentityEnums.cs
@@ -7,12 +7,5 @@
             Duplicate,
             MissingRequiredField            
         }
-
-        public enum StoreOptions
-        {
-            InMemory,
-            CouchDb,
-            SqlServer
-        }
     }
 }

--- a/Fabric.Identity.API/Startup.cs
+++ b/Fabric.Identity.API/Startup.cs
@@ -76,7 +76,7 @@ namespace Fabric.Identity.API
                 .AddSingleton<IEventSink>(serilogEventSink)
                 .AddSingleton(_appConfig)
                 .AddSingleton(_logger)
-                .AddIdentityServer(_appConfig, _certificateService, _logger, hostingOptions);
+                .AddIdentityServer(_appConfig, _certificateService, _logger, hostingOptions)
                 .AddAuthorizationServices()
                 .AddScoped<IUserResolverService, UserResolverService>()
                 .AddSingleton<ISerializationSettings, SerializationSettings>()

--- a/Fabric.Identity.API/Startup.cs
+++ b/Fabric.Identity.API/Startup.cs
@@ -74,7 +74,6 @@ namespace Fabric.Identity.API
                 .AddSingleton(_appConfig)
                 .AddSingleton(_logger)
                 .AddIdentityServer(_appConfig, _certificateService, _logger)
-                .AddScopedDecorator<IDocumentDbService, AuditingDocumentDbService>()
                 .AddAuthorizationServices()
                 .AddScoped<IUserResolverService, UserResolverService>()
                 .AddSingleton<ISerializationSettings, SerializationSettings>()

--- a/Fabric.Identity.API/Startup.cs
+++ b/Fabric.Identity.API/Startup.cs
@@ -69,11 +69,14 @@ namespace Fabric.Identity.API
             var identityServerApiSettings = _appConfig.IdentityServerConfidentialClientSettings;
             var eventLogger = LogFactory.CreateEventLogger(_loggingLevelSwitch, _appConfig.ApplicationInsights);
             var serilogEventSink = new SerilogEventSink(eventLogger);
+
+            services.TryAddSingleton(_appConfig.HostingOptions);
+            var hostingOptions = services.BuildServiceProvider().GetRequiredService<HostingOptions>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>()
                 .AddSingleton<IEventSink>(serilogEventSink)
                 .AddSingleton(_appConfig)
                 .AddSingleton(_logger)
-                .AddIdentityServer(_appConfig, _certificateService, _logger)
+                .AddIdentityServer(_appConfig, _certificateService, _logger, hostingOptions);
                 .AddAuthorizationServices()
                 .AddScoped<IUserResolverService, UserResolverService>()
                 .AddSingleton<ISerializationSettings, SerializationSettings>()

--- a/Fabric.Identity.API/appsettings.json
+++ b/Fabric.Identity.API/appsettings.json
@@ -23,8 +23,8 @@
   },
   "HostingOptions": {
     "UseIis": false,
-    "UseInMemoryStores": true,
-    "UseTestUsers": true
+    "UseTestUsers": true,
+    "StorageProvider": "InMemory" 
   },
   "CouchDbSettings": {
     "Server": "http://localhost:5984/",

--- a/Fabric.Identity.IntegrationTests/IntegrationTestsFixture.cs
+++ b/Fabric.Identity.IntegrationTests/IntegrationTestsFixture.cs
@@ -52,10 +52,10 @@ namespace Fabric.Identity.IntegrationTests
             CouchDbService.AddDocument(_client.ClientId, _client);
         }
 
-        public IntegrationTestsFixture(FabricIdentityEnums.StoreOptions storeOptions = FabricIdentityEnums.StoreOptions.InMemory)
+        public IntegrationTestsFixture(string storageProvider = FabricIdentityConstants.StorageProviders.InMemory)
         {
-            _identityTestServer = CreateIdentityTestServer(storeOptions);
-            _apiTestServer = CreateRegistrationApiTestServer(storeOptions);
+            _identityTestServer = CreateIdentityTestServer(storageProvider);
+            _apiTestServer = CreateRegistrationApiTestServer(storageProvider);
             HttpClient = GetHttpClient();
         }
 
@@ -103,13 +103,13 @@ namespace Fabric.Identity.IntegrationTests
 
         public HttpClient HttpClient { get; }
 
-        private TestServer CreateIdentityTestServer(FabricIdentityEnums.StoreOptions storeOptions)
+        private TestServer CreateIdentityTestServer(string storageProvider)
         {
             var hostingOptions = new HostingOptions
             {
                 UseIis = false,
                 UseTestUsers = true,
-                UseInMemoryStores = storeOptions == FabricIdentityEnums.StoreOptions.InMemory
+                StorageProvider = storageProvider
             };
 
             var builder = new WebHostBuilder();
@@ -128,7 +128,7 @@ namespace Fabric.Identity.IntegrationTests
             return new TestServer(builder);
         }
 
-        private TestServer CreateRegistrationApiTestServer(FabricIdentityEnums.StoreOptions storeOptions)
+        private TestServer CreateRegistrationApiTestServer(string storageProvider)
         {
             var options = new IdentityServerAuthenticationOptions
             {
@@ -144,7 +144,7 @@ namespace Fabric.Identity.IntegrationTests
             {
                 UseIis = false,
                 UseTestUsers = true,
-                UseInMemoryStores = storeOptions == FabricIdentityEnums.StoreOptions.InMemory
+                StorageProvider = storageProvider
             };
 
             var apiBuilder = new WebHostBuilder();

--- a/Fabric.Identity.IntegrationTests/UsersStoreTests.cs
+++ b/Fabric.Identity.IntegrationTests/UsersStoreTests.cs
@@ -20,7 +20,7 @@ namespace Fabric.Identity.IntegrationTests
 {
     public class UsersStoreTests : IntegrationTestsFixture
     {
-        public UsersStoreTests() : base(false)
+        public UsersStoreTests() : base(FabricIdentityEnums.StoreOptions.CouchDb)
         {
             var documentDbService = CouchDbService;
             _userStore = new CouchDbUserStore(documentDbService, _logger);

--- a/Fabric.Identity.IntegrationTests/UsersStoreTests.cs
+++ b/Fabric.Identity.IntegrationTests/UsersStoreTests.cs
@@ -20,7 +20,7 @@ namespace Fabric.Identity.IntegrationTests
 {
     public class UsersStoreTests : IntegrationTestsFixture
     {
-        public UsersStoreTests() : base(FabricIdentityEnums.StoreOptions.CouchDb)
+        public UsersStoreTests() : base(FabricIdentityConstants.StorageProviders.CouchDb)
         {
             var documentDbService = CouchDbService;
             _userStore = new CouchDbUserStore(documentDbService, _logger);

--- a/Fabric.Identity.IntegrationTests/appsettings.json
+++ b/Fabric.Identity.IntegrationTests/appsettings.json
@@ -21,8 +21,8 @@
   },
   "HostingOptions": {
     "UseIis": false,
-    "UseInMemoryStores": true,
-    "UseTestUsers": true
+    "UseTestUsers": true,
+    "StorageProvider": "InMemory" 
   },
   "CouchDbSettings": {
     "Server": "http://localhost:5984/",


### PR DESCRIPTION
I Upgraded the IntegrationTestFixture so it can support more than one type of storage provider.
Also, removed overriding the IDocumentDbService in the app's DI container with one from the IntegrationTestFixture so we can let the app construct all the dependencies itself, and we only override config in the test fixture to hit the set of stores we want.
Shifted the HostingOptions class to use a member of the new StorageProviders class to specify the type of storage provider, letting support more than two.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/87)
<!-- Reviewable:end -->
