### PR TITLE
added some basic scripts to run tests more easily.

### DIFF
--- a/Fabric.Identity.API/scripts/run-all-tests.sh
+++ b/Fabric.Identity.API/scripts/run-all-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+couchusername=$1
+couchpassword=$2
+
+./run-unit-tests.sh
+./run-integration-tests.sh $couchusername $couchpassword
+./run-functional-tests.sh $couchusername $couchpassword

--- a/Fabric.Identity.API/scripts/run-functional-tests.sh
+++ b/Fabric.Identity.API/scripts/run-functional-tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+couchusername=$1
+couchpassword=$2
+
+docker stop functional-couchdb
+docker rm functional-couchdb
+docker volume rm identity-func-db-data
+docker stop functional-authorization
+docker rm functional-authorization
+docker stop functional-identity
+docker rm functional-identity
+
+docker network create functional-tests
+
+docker run -d --name functional-couchdb \
+	-p 5984:5984 \
+	-e COUCHDB_USER=$couchusername \
+	-e COUCHDB_PASSWORD=$couchpassword \
+	-v identity-func-db-data://opt/couch/data \
+	--network="functional-tests" \
+	healthcatalyst/fabric.docker.couchdb
+echo "started couchdb"
+sleep 15 
+
+docker run -d --name functional-authorization \
+	-p 5004:5004 \
+	-e COUCHDBSETTINGS__USERNAME=$couchusername \
+	-e COUCHDBSETTINGS__PASSWORD=$couchpassword \
+	-e COUCHDBSETTINGS__SERVER=http://functional-couchdb:5984 \
+	-e IDENTITYSERVERCONFIDENTIALCLIENTSETTINGS__AUTHORITY=http://functional-identity:5001 \
+	--network="functional-tests" \
+	healthcatalyst/fabric.authorization
+echo "started authorization"
+sleep 3
+cd ..
+dotnet publish -o obj/Docker/publish
+echo "published api"
+docker build -t identity.functional.api .
+echo "built image"
+
+docker run -d --name functional-identity \
+	-p 5001:5001 \
+	-e COUCHDBSETTINGS__USERNAME=$couchusername \
+        -e COUCHDBSETTINGS__PASSWORD=$couchpassword \
+	-e COUCHDBSETTINGS__SERVER=http://functional-couchdb:5984 \
+	-e HOSTINGOPTIONS__STORAGEPROVIDER="CouchDB" \
+	--network="functional-tests" \
+	identity.functional.api
+echo "started api"
+sleep 3
+
+cd ../../Fabric.Identity/Fabric.Identity.FunctionalTests
+npm install
+npm test
+
+docker stop functional-couchdb
+docker rm functional-couchdb 
+docker volume rm identity-func-db-data
+docker stop functional-authorization 
+docker rm functional-authorization 
+docker stop functional-identity 
+docker rm functional-identity

--- a/Fabric.Identity.API/scripts/run-integration-tests.sh
+++ b/Fabric.Identity.API/scripts/run-integration-tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+couchusername=$1
+couchpassword=$2
+
+docker stop identity.integration.couchdb
+docker rm identity.integration.couchdb
+docker volume rm identity-int-db-data
+docker run -d --name identity.integration.couchdb -p 5984:5984 -e COUCHDB_USER=$couchusername -e COUCHDB_PASSWORD=$couchpassword -v identity-int-db-data://opt/couch/data healthcatalyst/fabric.docker.couchdb
+
+docker stop identity.integration.openldap
+docker rm identity.integration.openldap
+docker run -d --name identity.integration.openldap -d -p 389:389 -e LDAP_ADMIN_PASSWORD=password healthcatalyst/fabric.docker.openldap
+export COUCHDBSETTINGS__USERNAME=$couchusername
+export COUCHDBSETTINGS__PASSWORD=$couchpassword
+
+sleep 3
+
+dotnet test ../../Fabric.Identity.IntegrationTests/Fabric.Identity.IntegrationTests.csproj
+
+docker stop identity.integration.couchdb
+docker rm identity.integration.couchdb 
+docker volume rm identity-int-db-data
+docker stop identity.integration.openldap 
+docker rm identity.integration.openldap

--- a/Fabric.Identity.API/scripts/run-unit-tests.sh
+++ b/Fabric.Identity.API/scripts/run-unit-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dotnet test ../../Fabric.Identity.UnitTests/Fabric.Identity.UnitTests.csproj


### PR DESCRIPTION
These scripts are designed to be run from the scripts directory. They basically mimic what the CI build and release pipeline do. 

You can run each script individually, or run the run-all-tests.sh script to run unit, integration and functional tests in one shot.

All the scripts except for the run-unit-tests.sh script take two parameters, one for the couchdb username and one for the couchdb password.

You'll need to have docker running, as we spin up couchdb and openldap for the integration tests as a container. For the functional tests we run couchdb, authorization and identity as containers. We build the identity container from the code in your dev environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/88)
<!-- Reviewable:end -->
