### PR TITLE
Updated the Windows Server Hosting bundle version number

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -290,8 +290,8 @@ if((Test-Path $zipPackage))
 if(!(Test-PrerequisiteExact "*.NET Core*Windows Server Hosting*" 1.1.30327.81))
 {    
     try{
-        Write-Console "Windows Server Hosting Bundle version 1.1.30327.81 not installed...installing version 1.1.30327.81"        
-        Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=844461 -OutFile $env:Temp\bundle.exe
+        Write-Console "Windows Server Hosting Bundle version 1.1.30327.81 not installed...installing version 1.1.30503.82"        
+        Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=848766 -OutFile $env:Temp\bundle.exe
         Start-Process $env:Temp\bundle.exe -Wait -ArgumentList '/quiet /install'
         net stop was /y
         net start w3svc			

--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -287,10 +287,10 @@ if((Test-Path $zipPackage))
 }
 
 
-if(!(Test-PrerequisiteExact "*.NET Core*Windows Server Hosting*" 1.1.30327.81))
+if(!(Test-PrerequisiteExact "*.NET Core*Windows Server Hosting*" 1.1.30503.82))
 {    
     try{
-        Write-Console "Windows Server Hosting Bundle version 1.1.30327.81 not installed...installing version 1.1.30503.82"        
+        Write-Console "Windows Server Hosting Bundle version 1.1.30503.82 not installed...installing version 1.1.30503.82"        
         Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=848766 -OutFile $env:Temp\bundle.exe
         Start-Process $env:Temp\bundle.exe -Wait -ArgumentList '/quiet /install'
         net stop was /y


### PR DESCRIPTION
This will pull the server hosting bundle that has the 1.0.5 and 1.1.2 runtimes. 

Runtimes are not to be confused with SDK - we use the 1.0.4 SDK to build and target the 1.1.2 runtime. This originally confused me, which is why we were pulling the hosting bundle with the 1.0.4 and 1.1.1 runtimes. This would have resulted in having to install the 1.1.2 runtime manually, or getting a 502.5 error on application start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/137)
<!-- Reviewable:end -->
