### PR TITLE
Set IssuerUri config to empty so Identity sets it based on the request.

### DIFF
--- a/Fabric.Identity.API/web.config
+++ b/Fabric.Identity.API/web.config
@@ -14,6 +14,7 @@
       <environmentVariables>
         <clear />
         <environmentVariable name="HostingOptions__UseIis" value="true" />
+        <environmentVariable name="IssuerUri" value="" />
       </environmentVariables>
     </aspNetCore>
   </system.webServer>


### PR DESCRIPTION
We originally made this a config setting for when running behind an nginx proxy. In that scenario, identity was calculating the wrong uri, behind IIS, it calculates the correct uri, so for IIS deployments set the config to an empty string so that Identity can set the IssuerUri internally, which is more secure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/171)
<!-- Reviewable:end -->
