### PR TITLE
do not require clientId in user search to support fabric.auth searche…

### DIFF
--- a/Fabric.Identity.API/Management/UsersController.cs
+++ b/Fabric.Identity.API/Management/UsersController.cs
@@ -102,13 +102,6 @@ namespace Fabric.Identity.API.Management
 
         private async Task<IActionResult> ProcessSearchRequest(string clientId, IEnumerable<string> userIds)
         {
-            if (string.IsNullOrEmpty(clientId))
-            {
-                return CreateFailureResponse(
-                    "No client id was included in the request. Please specify a client id",
-                    HttpStatusCode.BadRequest);
-            }
-
             var docIds = userIds.Select(id => id?.ToLower()).ToList();
             if (!docIds.Any() || docIds.All(string.IsNullOrEmpty))
             {
@@ -116,12 +109,14 @@ namespace Fabric.Identity.API.Management
                     HttpStatusCode.BadRequest);
             }
 
-            var client = _clientManagementStore.FindClientByIdAsync(clientId).Result;
-
-            if (string.IsNullOrEmpty(client?.ClientId))
+            if (!string.IsNullOrEmpty(clientId))
             {
-                return CreateFailureResponse($"The specified client with id: {clientId} was not found",
-                    HttpStatusCode.NotFound);
+                var client = _clientManagementStore.FindClientByIdAsync(clientId).Result;
+                if (string.IsNullOrEmpty(client?.ClientId))
+                {
+                    return CreateFailureResponse($"The specified client with id: {clientId} was not found",
+                        HttpStatusCode.NotFound);
+                }
             }
 
             var users = await _userStore.GetUsersBySubjectIdAsync(docIds);

--- a/Fabric.Identity.API/Models/ModelExtensions.cs
+++ b/Fabric.Identity.API/Models/ModelExtensions.cs
@@ -264,7 +264,6 @@ namespace Fabric.Identity.API.Models
 
             if (!string.IsNullOrEmpty(clientId))
             {
-
                 var lastLoginForClient = user.LastLoginDatesByClient
                     .SingleOrDefault(l => l.ClientId.Equals(clientId, StringComparison.OrdinalIgnoreCase));
 

--- a/Fabric.Identity.API/Models/ModelExtensions.cs
+++ b/Fabric.Identity.API/Models/ModelExtensions.cs
@@ -260,10 +260,16 @@ namespace Fabric.Identity.API.Models
 
         public static UserApiModel ToUserViewModel(this User user, string clientId)
         {
-            var lastLoginForClient = user.LastLoginDatesByClient
-                .SingleOrDefault(l => l.ClientId.Equals(clientId, StringComparison.OrdinalIgnoreCase));
+            DateTime? dateToSet = null;
 
-            DateTime? dateToSet = lastLoginForClient?.LoginDate;
+            if (!string.IsNullOrEmpty(clientId))
+            {
+
+                var lastLoginForClient = user.LastLoginDatesByClient
+                    .SingleOrDefault(l => l.ClientId.Equals(clientId, StringComparison.OrdinalIgnoreCase));
+
+                dateToSet = lastLoginForClient?.LoginDate;
+            }
 
             return new UserApiModel
             {

--- a/Fabric.Identity.IntegrationTests/ControllerTests/InMemory/UsersControllerTests.cs
+++ b/Fabric.Identity.IntegrationTests/ControllerTests/InMemory/UsersControllerTests.cs
@@ -139,13 +139,13 @@ namespace Fabric.Identity.IntegrationTests.ControllerTests.InMemory
         }
 
         [Fact]
-        public async Task UsersController_Get_FindUsersByDocumentId_NoClientId_BadRequest()
+        public async Task UsersController_Get_FindUsersByDocumentId_NoClientId_ReturnsOk()
         {
             var numberOfUsers = 1;
             var usersQuery = await CreateUsersAndQuery(numberOfUsers, string.Empty);
             var response = await HttpClient.SendAsync(new HttpRequestMessage(new HttpMethod("GET"), $"{_usersSearchApiBaseUrl}{usersQuery}"));
 
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
…s for users in roles that are shared across clients

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/175)
<!-- Reviewable:end -->
