### PR TITLE
Fixed search service url.

### DIFF
--- a/Fabric.Identity.API/Services/IdPSearchServiceProvider.cs
+++ b/Fabric.Identity.API/Services/IdPSearchServiceProvider.cs
@@ -82,7 +82,7 @@ namespace Fabric.Identity.API.Services
             var baseUri = _appConfig.IdentityProviderSearchSettings.BaseUrl.EnsureTrailingSlash();
 
             var searchServiceUrl =
-                $"{baseUri}{_appConfig.IdentityProviderSearchSettings.GetUserEndpoint.EnsureTrailingSlash()}{subjectId}";
+                $"{baseUri}{_appConfig.IdentityProviderSearchSettings.GetUserEndpoint}{subjectId}";
 
             var httpRequestMessage = _httpRequestMessageFactory.CreateWithAccessToken(HttpMethod.Get,
                 new Uri(searchServiceUrl),


### PR DESCRIPTION
the call to ensure trailing slash was building a url that looked like:

http://localhost:5009/v1/principals/user?subjectid=/DOMAIN\user

instead of:

http://localhost:5009/v1/principals/user?subjectid=DOMAIN\user

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/197)
<!-- Reviewable:end -->
