### PR TITLE
User/ken/fabric identity registration script changes

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -104,7 +104,7 @@ function Add-DiscoveryRegistration($discoveryUrl, $serviceUrl, $credential)
         Description = "The Fabric.Identity service provides centralized authentication across the Fabric ecosystem."
     }
 
-    $url = "$discoveryUrl/v1/Services"
+    $url = "$discoveryUrl/Services"
     $jsonBody = $registrationBody | ConvertTo-Json	
     try{
         Invoke-RestMethod -Method Post -Uri "$url" -Body "$jsonBody" -ContentType "application/json" -Credential $credential | Out-Null
@@ -177,7 +177,7 @@ function Get-ApplicationEndpoint($appName, $appEndPoint)
 function Get-DiscoveryServiceUrl($discoUrl)
 {
     if([string]::IsNullOrEmpty($discoUrl)){
-        return "https://$env:computername.$($env:userdnsdomain.tolower())/DiscoveryService"
+        return "https://$env:computername.$($env:userdnsdomain.tolower())/DiscoveryService/v1"
     }else{
         return $discoUrl
     }
@@ -504,7 +504,7 @@ if($identityDbConnStr){
 }
 
 if(!($noDiscoveryService) -and $discoveryServiceUrl){
-    $environmentVariables.Add("DiscoveryServiceEndpoint", "$discoveryServiceUrl/v1/")
+    $environmentVariables.Add("DiscoveryServiceEndpoint", "$discoveryServiceUrl")
     $environmentVariables.Add("UseDiscoveryService", "true")
 }else{
     $environmentVariables.Add("UseDiscoveryService", "false")

--- a/Fabric.Identity.API/scripts/Register.ps1
+++ b/Fabric.Identity.API/scripts/Register.ps1
@@ -16,11 +16,11 @@ function Get-AuthorizationServiceUrl(){
 
 function Get-DiscoveryServiceUrl(){
     $hostName = Get-FullyQualifiedHostName
-    return "$hostName/DiscoveryService"
+    return "$hostName/DiscoveryService/v1"
 }
 
 function Get-ApplicationUrl($serviceName, $serviceVersion, $discoveryServiceUrl){
-    $discoveryRequest = "$discoveryServiceUrl/v1/Services?`$filter=ServiceName eq '$serviceName' and Version eq $serviceVersion&`$select=ServiceUrl&`$orderby=Version desc"
+    $discoveryRequest = "$discoveryServiceUrl/Services?`$filter=ServiceName eq '$serviceName' and Version eq $serviceVersion&`$select=ServiceUrl&`$orderby=Version desc"
     $discoveryResponse = Invoke-RestMethod -Method Get -Uri $discoveryRequest -UseDefaultCredentials
     $serviceUrl = $discoveryResponse.value.ServiceUrl
     if([string]::IsNullOrWhiteSpace($serviceUrl)){
@@ -564,7 +564,7 @@ function Invoke-RegisterClients($clients, $identityServiceUrl, $accessToken, $di
 				$clientSecret = Add-ClientRegistration -authUrl $identityServiceUrl -body $jsonBody -accessToken $accessToken 
             }
 
-            if (![string]::IsNullOrEmpty($clientSecret) -and ![string]::IsNullOrWhiteSpace($clientSecret)) {
+            if (![string]::IsNullOrEmpty($clientSecret) -and ![string]::IsNullOrWhiteSpace($clientSecret) -and !$client.allowedGrantTypes.grantType.Contains("hybrid")) {
                 $configPath = Get-WebConfigPath -service $client -discoveryServiceUrl $discoveryServiceUrl
                 Invoke-WriteSecretToConfig -service $client -secret $clientSecret.Trim() -configPath $configPath
             }


### PR DESCRIPTION
v1 changes to identity and registration scripts. Looks like the code was changed to bring back the if block !$client.allowedGrantTypes.grantType.Contains("hybrid"). The nuget just hasn't been updated in the DOS Installer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/214)
<!-- Reviewable:end -->
