### PR TITLE
added upgrade change to append a /v1 to discoveryservice url if not present

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -151,10 +151,10 @@ function Get-DiscoveryServiceUrl($discoUrl)
     if([string]::IsNullOrEmpty($discoUrl)){
         return "https://$env:computername.$($env:userdnsdomain.tolower())/DiscoveryService/v1"
     }else{
-	      $discoUrl = $discoUrl.TrimEnd('/')
+	      $discoUrl = $discoUrl.TrimEnd("/")
           if ($discoUrl -notmatch "/v\d")
 		  {
-	  		  return $discoUrl + '/v1'
+	  		  return $discoUrl + "/v1"
 		  }
 		  else 
 		  {

--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -151,7 +151,15 @@ function Get-DiscoveryServiceUrl($discoUrl)
     if([string]::IsNullOrEmpty($discoUrl)){
         return "https://$env:computername.$($env:userdnsdomain.tolower())/DiscoveryService/v1"
     }else{
-        return $discoUrl
+		  $hasversion = $discoUrl -match "/v\d"
+		  if (!$hasversion)
+		  {
+	  		  return $discoUrl + '/v1'
+		  }
+		  else 
+		  {
+		  	  return $discoUrl
+		  }
     }
 }
 

--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -151,8 +151,8 @@ function Get-DiscoveryServiceUrl($discoUrl)
     if([string]::IsNullOrEmpty($discoUrl)){
         return "https://$env:computername.$($env:userdnsdomain.tolower())/DiscoveryService/v1"
     }else{
-		  $hasversion = $discoUrl -match "/v\d"
-		  if (!$hasversion)
+	      $discoUrl = $discoUrl.TrimEnd('/')
+          if ($discoUrl -notmatch "/v\d")
 		  {
 	  		  return $discoUrl + '/v1'
 		  }

--- a/Fabric.Identity.API/scripts/Register.ps1
+++ b/Fabric.Identity.API/scripts/Register.ps1
@@ -24,7 +24,7 @@ function Get-ApplicationUrl($serviceName, $serviceVersion, $discoveryServiceUrl)
     $discoveryResponse = Invoke-RestMethod -Method Get -Uri $discoveryRequest -UseDefaultCredentials
     $serviceUrl = $discoveryResponse.value.ServiceUrl
     if([string]::IsNullOrWhiteSpace($serviceUrl)){
-	    Write-Error "There was an error registering the service $serviceName, using DiscoveryService url $discoveryRequest."
+	    Write-Error "There was an error getting the service registration for $serviceName, using DiscoveryService url $discoveryRequest."
         throw "The service $serviceName version $serviceVersion and $serviceUrl is not registered with the Discovery service. Make sure that this version of the service is registered w/ Discovery service before proceeding. Halting installation."
     }
     return $serviceUrl

--- a/Fabric.Identity.API/scripts/Register.ps1
+++ b/Fabric.Identity.API/scripts/Register.ps1
@@ -24,7 +24,8 @@ function Get-ApplicationUrl($serviceName, $serviceVersion, $discoveryServiceUrl)
     $discoveryResponse = Invoke-RestMethod -Method Get -Uri $discoveryRequest -UseDefaultCredentials
     $serviceUrl = $discoveryResponse.value.ServiceUrl
     if([string]::IsNullOrWhiteSpace($serviceUrl)){
-        throw "The service $serviceName version $serviceVersion is not registered with the Discovery service. Make sure that this version of the service is registered w/ Discovery service before proceeding. Halting installation."
+	    Write-Error "There was an error registering the service $serviceName, using DiscoveryService url $discoveryRequest."
+        throw "The service $serviceName version $serviceVersion and $serviceUrl is not registered with the Discovery service. Make sure that this version of the service is registered w/ Discovery service before proceeding. Halting installation."
     }
     return $serviceUrl
 }


### PR DESCRIPTION
I got an error upgrading, but not the same error, I got it in the DiscoveryServiceClient, so I added code to add /v1 to the default discovery service url, if not present from having a previous installation. 
I still added more error code to where his error was thrown in the Fabric.Registration, but I think the natural progression would be to upgrade first Fabric.Identity, then Fabric.Authorization, then Fabric.Registration, and this code addition will work. If they were to skip over Fabric.Identity, then the /v1 code addition would need to be duplicated in the others.  I haven't been able to test the error code addition, since I didn't get the same error as him. May need to over the shoulder with him, through his process before I check in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/217)
<!-- Reviewable:end -->
