### PR TITLE
Trim ending discovery slash

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1
@@ -399,6 +399,8 @@ if(!($noDiscoveryService)){
     if(![string]::IsNullOrEmpty($userEnteredDiscoveryServiceUrl)){   
          $discoveryServiceUrl = $userEnteredDiscoveryServiceUrl
     }
+
+    $discoveryServiceUrl = $discoveryServiceUrl.TrimEnd('/')
 }
 
 


### PR DESCRIPTION
Trim ending slash after prompting user input for discovery url so either user input or already existing discovery url has it's ending slash removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/221)
<!-- Reviewable:end -->
