### PR TITLE
Since we aren't using the output of the function, pipe it to null so …

### DIFF
--- a/Fabric.Identity.API/scripts/Register.ps1
+++ b/Fabric.Identity.API/scripts/Register.ps1
@@ -675,7 +675,7 @@ function Invoke-RegisterRolesAndPermissions($grainName, $securableItemName, $sec
         $addedRole = Invoke-AddOrGetRole -authUrl $authorizationServiceURL -name $roleName -displayName $roleDisplayName -description $roleDescription -grain $grainName -securableItem $securableItemName -accessToken $accessToken
         if(!([string]::IsNullOrEmpty($($role.groupName)))){
             $group = Invoke-AddOrGetGroup -authUrl $authorizationServiceURL -name $role.groupName -source "custom" -accessToken $accessToken
-            Add-RoleToGroupSafe -authUrl $authorizationServiceURL -groupName $role.groupName -role $addedRole -accessToken $accessToken
+            Add-RoleToGroupSafe -authUrl $authorizationServiceURL -groupName $role.groupName -role $addedRole -accessToken $accessToken | Out-Null
         }
         foreach($permission in $role.permission){
             $permissionName = $permission.name


### PR DESCRIPTION
…it doesn't clutter the output stream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/242)
<!-- Reviewable:end -->
