### PR TITLE
UserId needed to be subject id for Azure AD

### DIFF
--- a/Fabric.Identity.API/Quickstart/Account/AccountController.cs
+++ b/Fabric.Identity.API/Quickstart/Account/AccountController.cs
@@ -247,7 +247,7 @@ namespace IdentityServer4.Quickstart.UI
             //issue authentication cookie for user
             var user = await _userLoginManager.UserLogin(
                 claimInformation.Provider,
-                claimInformation.UserId,
+                _claimsService.GetEffectiveUserId(claimInformation),
                 claimInformation.Claims,
                 claimInformation?.ClientId);
             

--- a/Fabric.Identity.API/Services/IClaimsService.cs
+++ b/Fabric.Identity.API/Services/IClaimsService.cs
@@ -10,5 +10,6 @@ namespace Fabric.Identity.API.Services
     {
         ClaimsResult GenerateClaimsForIdentity(AuthenticateInfo info, AuthorizationRequest context);
         string GetEffectiveSubjectId(ClaimsResult ClaimInformation, User user);
+        string GetEffectiveUserId(ClaimsResult claimInformation);
     }
 }


### PR DESCRIPTION
UserId needed to be subject id for Azure AD

Moved around some private functions to keep all public functions together.

Added new function "GetEffectiveUserId".  Based on conversation with @michaelvidal24 , The user Id that is used to store a user in the database was being set to values for AD, even though the user was logging into Identity with an Azure AD account.  This will select the subject ID if it is from Azure AD, else it will use the user Id claim that was pulled in the "GetUserIdClaim" step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/healthcatalyst/fabric.identity/265)
<!-- Reviewable:end -->
