### PR TITLE
Give virtual app pool account proper read permissions

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -1041,7 +1041,7 @@ function Find-IISAppPoolUser {
     $appPool = (Get-Item (Join-Path 'IIS:\AppPools\' $appPoolName))
 
     if($appPool.processModel.identityType -eq 'ApplicationPoolIdentity') {
-        Write-DosMessage -Level "Error" -Message "Application Pool users of identity type `"ApplicationPoolIdentity`" are not allowed."
+        return "IIS AppPool\$appPoolName"
     }
 
     $username = $appPool.processModel.username


### PR DESCRIPTION
Possible that this may give the correct permissions to an 'ApplicationPoolIdentity' virtual account, would need to do more testing