### PR TITLE
Move thumbprint so its always visible

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -132,7 +132,7 @@ function Get-Certificates([string] $primarySigningCertificateThumbprint, [string
                 'Expiration' = $_.NotAfter
                 };
                 $index ++} |
-                Format-Table Index,Name,Subject,Expiration,Thumbprint  -AutoSize | Out-Host
+                Format-Table Index, Thumbprint, Name, Subject, Expiration -AutoSize | Out-Host
             do {
                 if($attempts -gt 10){
                     Write-DosMessage -Level "Error" -Message "An invalid certificate has been selected."


### PR DESCRIPTION
Moving thumbprint to the first of the output after getting feedback from Command Center that sometimes the name is a match and the thumbprint gets cut off in our formatted table.