### PR TITLE
Fixed an issue where we were adding two name claims to the claims col…

### DIFF
--- a/Fabric.Identity.API/FabricIdentityConstants.cs
+++ b/Fabric.Identity.API/FabricIdentityConstants.cs
@@ -11,6 +11,11 @@
         public static readonly string AuditEventCategory = "Audit";
         public static readonly string FabricIdentityClient = "fabric-identity-client";
 
+        public static class PublicClaimTypes
+        {
+            public static readonly string UserPrincipalName = "upn";
+        }
+
         public static class StorageProviders
         {
             public const string InMemory = "inmemory";

--- a/Fabric.Identity.API/Management/UserLoginManager.cs
+++ b/Fabric.Identity.API/Management/UserLoginManager.cs
@@ -64,8 +64,15 @@ namespace Fabric.Identity.API.Management
 
         private string GetUserName(User user)
         {
-            var upn = user.Claims.FirstOrDefault(c => c.Type == FabricIdentityConstants.PublicClaimTypes.UserPrincipalName)?.Value;
-            var userName = !string.IsNullOrEmpty(upn) ? upn : user.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Name)?.Value;
+            var userName = user.SubjectId;
+            if (user.Claims.Any(c => c.Type == FabricIdentityConstants.PublicClaimTypes.UserPrincipalName))
+            {
+                userName = user.Claims.First(c => c.Type == FabricIdentityConstants.PublicClaimTypes.UserPrincipalName).Value;
+            }
+            else if (user.Claims.Any(c => c.Type == JwtClaimTypes.Name))
+            {
+                userName = user.Claims.First(c => c.Type == JwtClaimTypes.Name).Value;
+            }
             return userName;
         }
 

--- a/Fabric.Identity.API/Management/UserLoginManager.cs
+++ b/Fabric.Identity.API/Management/UserLoginManager.cs
@@ -64,17 +64,8 @@ namespace Fabric.Identity.API.Management
 
         private string GetUserName(User user)
         {
-            var userName = string.Empty;
             var upn = user.Claims.FirstOrDefault(c => c.Type == FabricIdentityConstants.PublicClaimTypes.UserPrincipalName)?.Value;
-            var name = user.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Name)?.Value;
-            if (!string.IsNullOrEmpty(upn))
-            {
-                userName = upn;
-            }
-            else if (!string.IsNullOrEmpty(name))
-            {
-                userName = name;
-            }
+            var userName = !string.IsNullOrEmpty(upn) ? upn : user.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Name)?.Value;
             return userName;
         }
 


### PR DESCRIPTION
…lection. This was breaking deserialization in the .net core openid connection auth middleware as it was expecting a string not an array.

Still need to beef up the unit tests around the changes.