### PR TITLE
Add check to see if any switches were applied

### DIFF
--- a/Fabric.Identity.API/scripts/Register-Identity-IdPSS.ps1
+++ b/Fabric.Identity.API/scripts/Register-Identity-IdPSS.ps1
@@ -15,12 +15,11 @@ param(
 
 if(!($registerIdentity) -and !($registerIdPSS))
 {
-	Write-Host " You must register either Identity and/or IdPSS by adding their respective switch.
+	throw " You must register either Identity and/or IdPSS by adding their respective switch.
 	Examples:
 		.\Register-Identity-IdPSS.ps1 -registerIdentity
 		.\Register-Identity-IdPSS.ps1 -registerIdPSS
-		.\Register-Identity-IdPSS.ps1 -registerIdentity -registerIdPSS" -ForegroundColor Red -BackgroundColor Black
-	exit
+		.\Register-Identity-IdPSS.ps1 -registerIdentity -registerIdPSS"
 }
 
 $fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"

--- a/Fabric.Identity.API/scripts/Register-Identity-IdPSS.ps1
+++ b/Fabric.Identity.API/scripts/Register-Identity-IdPSS.ps1
@@ -13,6 +13,16 @@ param(
     [switch] $registerIdPSS
 )
 
+if(!($registerIdentity) -and !($registerIdPSS))
+{
+	Write-Host " You must register either Identity and/or IdPSS by adding their respective switch.
+	Examples:
+		.\Register-Identity-IdPSS.ps1 -registerIdentity
+		.\Register-Identity-IdPSS.ps1 -registerIdPSS
+		.\Register-Identity-IdPSS.ps1 -registerIdentity -registerIdPSS" -ForegroundColor Red -BackgroundColor Black
+	exit
+}
+
 $fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
 if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"


### PR DESCRIPTION
Check to see if user supplied either registerIdentity and/or registerIdPSS switch with this script. If not, display a message with examples to use.