### PR TITLE
Remove unused nuget package.

### DIFF
--- a/Fabric.Identity.API/Fabric.Identity.API.csproj
+++ b/Fabric.Identity.API/Fabric.Identity.API.csproj
@@ -67,7 +67,6 @@
     <PackageReference Include="MyCouch" Version="5.0.1" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
     <PackageReference Include="Polly" Version="5.3.0" />
-    <PackageReference Include="RestSharp.Newtonsoft.Json.NetCore" Version="1.0.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.2.1" />

--- a/Fabric.Identity.API/Services/LinuxCertificateService.cs
+++ b/Fabric.Identity.API/Services/LinuxCertificateService.cs
@@ -3,7 +3,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Fabric.Identity.API.Configuration;
 using Fabric.Platform.Shared.Exceptions;
-using RestSharp.Extensions;
 
 namespace Fabric.Identity.API.Services
 {
@@ -49,11 +48,8 @@ namespace Fabric.Identity.API.Services
 
         private X509Certificate2 GetCertFromFile(string certPath, string passwordPath)
         {
-            using (var certStream = new FileStream(certPath, FileMode.Open, FileAccess.Read))
-            {
-                var password = File.ReadAllText(passwordPath).Trim();
-                return new X509Certificate2(certStream.ReadAsBytes(), password);
-            }
+            var password = File.ReadAllText(passwordPath).Trim();
+            return new X509Certificate2(certPath, password);
         }
     }
 }


### PR DESCRIPTION
Removed an unused nuget that was pulling in another nuget that was causing build warnings.