### PR TITLE
Remove progress bar when downloading assets during installation

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -1,13 +1,5 @@
-# Import Fabric Install Utilities
-$fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
-if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
-    Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
-}
-Import-Module -Name $fabricInstallUtilities -Force
-
 # Import Dos Install Utilities
-$minVersion = [System.Version]::new(1, 0, 234 , 0)
+$minVersion = [System.Version]::new(1, 0, 248 , 0)
 try {
     Get-InstalledModule -Name DosInstallUtilities -MinimumVersion $minVersion -ErrorAction Stop
 } catch {
@@ -15,6 +7,14 @@ try {
     Install-Module DosInstallUtilities -Scope CurrentUser -MinimumVersion $minVersion -Force
 }
 Import-Module -Name DosInstallUtilities -MinimumVersion $minVersion -Force
+
+# Import Fabric Install Utilities
+$fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
+if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
+    Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -NoCache -OutFile $fabricInstallUtilities
+}
+Import-Module -Name $fabricInstallUtilities -Force
 
 function Get-FullyQualifiedInstallationZipFile([string] $zipPackage, [string] $workingDirectory){
     if((Test-Path $zipPackage))
@@ -37,7 +37,7 @@ function Install-DotNetCoreIfNeeded([string] $version, [string] $downloadUrl){
     {    
         try{
             Write-DosMessage -Level "Information" -Message "Windows Server Hosting Bundle version $version not installed...installing version $version"        
-            Invoke-WebRequest -Uri $downloadUrl -OutFile $env:Temp\bundle.exe
+            Get-WebRequestDownload -Uri $downloadUrl -OutFile $env:Temp\bundle.exe
             Start-Process $env:Temp\bundle.exe -Wait -ArgumentList '/quiet /install'
             Restart-W3SVC
         }catch{

--- a/Fabric.Identity.API/scripts/Install-Identity.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity.ps1
@@ -23,7 +23,7 @@ Import-Module -Name .\Install-Identity-Utilities.psm1 -Force
 $fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
 if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -NoCache -OutFile $fabricInstallUtilities
 }
 Import-Module -Name $fabricInstallUtilities -Force
 

--- a/Fabric.Identity.API/scripts/tests/Install-Identity-Utilities.tests.ps1
+++ b/Fabric.Identity.API/scripts/tests/Install-Identity-Utilities.tests.ps1
@@ -34,20 +34,20 @@ Describe 'Install-DotNetCoreIfNeeded' -Tag 'Unit' {
     Context 'DotNetCore version is already installed'{
         It 'Should Not Install'{
             Mock -ModuleName Install-Identity-Utilities -CommandName Test-PrerequisiteExact -MockWith { return $true }
-            Mock -ModuleName Install-Identity-Utilities -CommandName Invoke-WebRequest -MockWith {}
+            Mock -ModuleName Install-Identity-Utilities -CommandName Get-WebRequestDownload -MockWith {}
             Install-DotNetCoreIfNeeded -version "1.1.1234.123" -downloadUrl "http://example.com"
-            Assert-MockCalled -ModuleName Install-Identity-Utilities -CommandName Invoke-WebRequest -Times 0 -Exactly
+            Assert-MockCalled -ModuleName Install-Identity-Utilities -CommandName Get-WebRequestDownload -Times 0 -Exactly
 
         }
         InModuleScope Install-Identity-Utilities {
             It 'Should install proper version' {
                 Mock -CommandName Test-PrerequisiteExact -MockWith { return $false }
-                Mock -CommandName Invoke-WebRequest -MockWith {}
+                Mock -CommandName Get-WebRequestDownload -MockWith {}
                 Mock -CommandName Start-Process -MockWith {}
                 Mock -CommandName Restart-W3SVC -MockWith {}
                 Mock -CommandName Remove-Item -MockWith {}
                 Install-DotNetCoreIfNeeded -version "1.1.1234.123" -downloadUrl "http://example.com"
-                Assert-MockCalled -CommandName Invoke-WebRequest -Times 1 -Exactly
+                Assert-MockCalled -CommandName Get-WebRequestDownload -Times 1 -Exactly
                 Assert-MockCalled -CommandName Start-Process -Times 1 -Exactly
                 Assert-MockCalled -CommandName Restart-W3SVC -Times 1 -Exactly
                 Assert-MockCalled -CommandName Remove-Item -Times 1 -Exactly
@@ -55,7 +55,7 @@ Describe 'Install-DotNetCoreIfNeeded' -Tag 'Unit' {
 
             It 'Should throw an exception if Start-Process throws' {
                 Mock -CommandName Test-PrerequisiteExact -MockWith { return $false }
-                Mock -CommandName Invoke-WebRequest -MockWith {}
+                Mock -CommandName Get-WebRequestDownload -MockWith {}
                 Mock -CommandName Start-Process -MockWith { throw }
                 Mock -CommandName Restart-W3SVC -MockWith {}
                 Mock -CommandName Remove-Item -MockWith {}


### PR DESCRIPTION
Using the newly introduced "Get-WebRequestDownload" function in DosInstallUtilities to remove the progress bar when downloading assets for installation.