### PR TITLE
I fixed the name being used to filter Azure settings for IdPSS.

### DIFF
--- a/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
+++ b/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
@@ -96,4 +96,4 @@ Set-IdentityProviderSearchServiceWebConfigSettings -webConfigPath $idpssConfig `
     -encryptionCert $certificates.SigningCertificate `
     -encryptionCertificateThumbprint $certificates.EncryptionCertificate.Thumbprint `
     -appInsightsInstrumentationKey $appInsightsKey `
-    -appName $idpssName 
+    -appName "Identity Provider Search Service" 


### PR DESCRIPTION
Bug link:
https://healthcatalyst.visualstudio.com/CAP/_workitems/edit/168485