### PR TITLE
Install and Import CatalystDosIdentity

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -484,7 +484,7 @@ function Add-RegistrationApiRegistration([string] $identityServerUrl, [string] $
 
 function Add-IdpssApiResourceRegistration($identityServiceUrl, $fabricInstallerSecret)
 {
-    $accessToken = Get-AccessToken -authUrl $identityServiceUrl -clientId "fabric-installer" -secret $fabricInstallerSecret -scope fabric/identity.manageresources
+    $accessToken = Get-AccessToken -identityUrl $identityServiceUrl -clientId "fabric-installer" -secret $fabricInstallerSecret -scope "fabric/identity.manageresources"
 
     Write-DosMessage -Level "Information" -Message "Registering IdentitySearchProvider API with Fabric.Identity..."
     $apiName = "idpsearch-api"

--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -16,6 +16,16 @@ if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
 }
 Import-Module -Name $fabricInstallUtilities -Force
 
+# Import CatalystDosIdentity
+$minDosIdentityVersion = [System.Version]::new(1, 4, 18200 , 12)
+try{
+    Get-InstalledModule -Name DosInstallUtilities -MinimumVersion $minDosIdentityVersion -ErrorAction Stop
+} catch{
+    Write-Host "Installing CatalystDosIdentity from Powershell Gallery"
+    Install-Module CatalystDosIdentity -Scope CurrentUser -MinimumVersion $minDosIdentityVersion -Force
+}
+Import-Module -Name CatalystDosIdentity -MinimumVersion $minVersion -Force
+
 function Get-FullyQualifiedInstallationZipFile([string] $zipPackage, [string] $workingDirectory){
     if((Test-Path $zipPackage))
     {


### PR DESCRIPTION
This fixes the issue where we could not create a registration body, and as a bonus since we import CataystDosIdentity after Fabric-Install-Utilities, we can use the CatalystDosIdentity version of Get-AccessToken.