### PR TITLE
DosInstallUtilities uses the AppName parameter, remove unused credential

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -484,7 +484,7 @@ function Add-RegistrationApiRegistration([string] $identityServerUrl, [string] $
 
 function Add-IdpssApiResourceRegistration($identityServiceUrl, $fabricInstallerSecret)
 {
-    $accessToken = Get-AccessToken -identityUrl $identityServiceUrl -clientId "fabric-installer" -secret $fabricInstallerSecret -scope "fabric/identity.manageresources"
+        $accessToken = Get-AccessToken -identityUrl $identityServiceUrl -clientId "fabric-installer" -secret $fabricInstallerSecret -scope "fabric/identity.manageresources"
 
     Write-DosMessage -Level "Information" -Message "Registering IdentitySearchProvider API with Fabric.Identity..."
     $apiName = "idpsearch-api"
@@ -1033,7 +1033,7 @@ function Set-IdentityProviderSearchServiceWebConfigSettings {
         [System.Security.Cryptography.X509Certificates.X509Certificate2] $encryptionCert,
         [string] $appName
     )
-    Write-Host "Setting IdPSS Web Config Settings."
+	Write-Host "Setting IdPSS Web Config Settings."
     Clear-IdentityProviderSearchServiceWebConfigAzureSettings -webConfigPath $webConfigPath
     $appSettings = @{}
     
@@ -1100,7 +1100,7 @@ function Set-IdentityProviderSearchServiceWebConfigSettings {
         $appSettings.Add("UseWindowsAuthentication", "false")
     }
 
-    Write-Host "Web Config Path: $($webConfigPath)"
+	Write-Host "Web Config Path: $($webConfigPath)"
 
     Set-WebConfigAppSettings $webConfigPath $appSettings | Out-Null
 }
@@ -1240,7 +1240,6 @@ function Get-IdpssWebDeployParameters{
         [Hashtable] $serviceConfig,
         [Parameter(Mandatory=$true)]
         [Hashtable] $commonConfig,
-        [PSCredential] $credential,
         [string] $applicationEndpoint,
         [string] $discoveryServiceUrl,
         [string] $noDiscoveryService,

--- a/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
+++ b/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
@@ -53,7 +53,6 @@ $idpssWebDeployParameters = Get-IdpssWebDeployParameters -serviceConfig $idpssCo
                         -applicationEndpoint $idpssServiceUrl `
                         -discoveryServiceUrl $discoveryServiceUrl `
                         -noDiscoveryService $noDiscoveryService `
-                        -credential $idpssIisUser.Credential `
                         -registrationApiSecret $registrationApiSecret `
                         -metadataConnectionString $metadataDatabase.DbConnectionString `
                         -currentDomain $currentUserDomain
@@ -97,4 +96,4 @@ Set-IdentityProviderSearchServiceWebConfigSettings -webConfigPath $idpssConfig `
     -encryptionCert $certificates.SigningCertificate `
     -encryptionCertificateThumbprint $certificates.EncryptionCertificate.Thumbprint `
     -appInsightsInstrumentationKey $appInsightsKey `
-    -appName "Identity Provider Search Service" 
+    -appName $idpssName 

--- a/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
+++ b/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
@@ -61,6 +61,7 @@ $idpssWebDeployParameters = Get-IdpssWebDeployParameters -serviceConfig $idpssCo
 $idpssInstallApplication = Publish-DosWebApplication -WebAppPackagePath $idpssInstallPackagePath `
                       -WebDeployParameters $idpssWebDeployParameters `
                       -AppPoolName $idpssConfigStore.appPoolName `
+					  -AppName $idpssConfigStore.appName `
                       -AppPoolCredential $idpssIisUser.Credential `
                       -AuthenticationType "Anonymous" `
                       -WebDeploy


### PR DESCRIPTION
DosInstallUtitlities uses the AppName parameter to display an information message for the service getting deployed.