### PR TITLE
tweaked parameters for Get-TenantSettingsFromInstallConfig

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -822,7 +822,7 @@ function Get-SettingsFromInstallConfig {
         [string] $setting
     )
 
-    return Get-TenantSettingsFromInstallConfig($installConfigPath, $scope, $setting)
+    return Get-TenantSettingsFromInstallConfig -installConfigPath $installConfigPath -scope $scope -setting $setting
 }
 
 function Get-TenantSettingsFromInstallConfig {


### PR DESCRIPTION
Refactored how the parameters for theGet-TenantSettingsFromInstallConfig variable were being passed.  Current version was throwing error and preventing correct install path from being passed.