### PR TITLE
updating to actually set-logging configuration for identity

### DIFF
--- a/Fabric.Identity.API/scripts/install.config
+++ b/Fabric.Identity.API/scripts/install.config
@@ -20,6 +20,10 @@
       <variable name="identityProviderSearchServiceService" value="" />
       <variable name="webServerDomain" value="" />
       <variable name="clientEnvironment" value="" />
+      <!-- The path where log messages should be written to during installation -->
+      <variable name="logFilePath" value="C:\DosInstall\logs\DosInstall.log" />
+      <!-- The minimum logging level that should be written during installation -->
+      <variable name="minimumLoggingLevel" value="Information" />
     </scope>
     <scope name="identity">
       <!-- The path to the location of the zip file that contains the binaries for Fabric.Identity -->


### PR DESCRIPTION
We seem to rely on the identity logs instead of the DosInstall logs. Just added the necessary variables to allow DosInstall logs to work also.