### PR TITLE
Use a filter to find graph api permissions

### DIFF
--- a/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
@@ -85,13 +85,14 @@ function New-FabricAzureADApplication() {
         [Microsoft.Open.AzureAD.Model.RequiredResourceAccess] $permission,
         [bool] $isMultiTenant = $false
     )
+    $groupMembershipClaims = 'SecurityGroup'
 
     $app = Get-AzureADApplication -Filter "DisplayName eq '$appName'" -Top 1
     if($null -eq $app) {
-        $app = New-AzureADApplication -Oauth2AllowImplicitFlow $true -RequiredResourceAccess $permission -DisplayName $appName -ReplyUrls $replyUrls.name -AvailableToOtherTenants $isMultiTenant
+        $app = New-AzureADApplication -Oauth2AllowImplicitFlow $true -RequiredResourceAccess $permission -DisplayName $appName -ReplyUrls $replyUrls.name -AvailableToOtherTenants $isMultiTenant -GroupMembershipClaims $groupMembershipClaims
     }
     else {
-        Set-AzureADApplication -ObjectId $app.ObjectId -RequiredResourceAccess $permission -Oauth2AllowImplicitFlow $true -ReplyUrls $replyUrls.name -AvailableToOtherTenants $isMultiTenant
+        Set-AzureADApplication -ObjectId $app.ObjectId -RequiredResourceAccess $permission -Oauth2AllowImplicitFlow $true -ReplyUrls $replyUrls.name -AvailableToOtherTenants $isMultiTenant -GroupMembershipClaims $groupMembershipClaims
     }
 
     return $app

--- a/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
@@ -21,7 +21,7 @@ else {
 
 function Get-GraphApiDirectoryReadPermissions() {
     try {
-        $aad = @((Get-AzureADServicePrincipal | Where-Object {$_.ServicePrincipalNames.Contains("https://graph.microsoft.com")}))[0]
+        $aad = @((Get-AzureADServicePrincipal -Filter "ServicePrincipalNames eq 'https://graph.microsoft.com'"))[0]
     }
     catch {
         Write-DosMessage -Level "Error" -Message "Was not able to get the Microsoft Graph API service principal."
@@ -49,7 +49,7 @@ function Get-GraphApiDirectoryReadPermissions() {
 
 function Get-GraphApiUserReadPermissions() {
     try {
-        $aad = @((Get-AzureADServicePrincipal | Where-Object {$_.ServicePrincipalNames.Contains("https://graph.microsoft.com")}))[0]
+        $aad = @((Get-AzureADServicePrincipal -Filter "ServicePrincipalNames eq 'https://graph.microsoft.com'"))[0]
     }
     catch {
         Write-DosMessage -Level "Error" -Message "Was not able to get the Microsoft Graph API service principal."
@@ -160,12 +160,15 @@ function Connect-AzureADTenant {
     param(
         [Parameter(Mandatory=$true)]
         [string] $tenantId,
-        [Parameter(Mandatory=$true)]
         [PSCredential] $credential
     )
 
     try {
-        Connect-AzureAD -Credential $credential -TenantId $tenantId | Out-Null
+        if($credential) {
+            Connect-AzureAD -Credential $credential -TenantId $tenantId | Out-Null
+        } else {
+            Connect-AzureAD -TenantId $tenantId | Out-Null
+        }
     }
     catch {
         Write-DosMessage -Level "Error" -Message  "Could not sign into tenant '$tenantId' with user '$($credential.UserName)'"

--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -26,7 +26,7 @@ try{
 }
 Import-Module -Name CatalystDosIdentity -MinimumVersion $minVersion -Force
 
-$Global:idPSSAppName = "IdentityProviderSearchService"
+$Global:idPSSAppName = "Identity Provider Search Service"
 
 function Get-FullyQualifiedInstallationZipFile([string] $zipPackage, [string] $workingDirectory){
     if((Test-Path $zipPackage))


### PR DESCRIPTION
Do not require PSCredentials (let the azureAD module handle that)