### PR TITLE
User/jason/handleduplicateregistrations

### DIFF
--- a/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
@@ -93,10 +93,12 @@ function New-FabricAzureADApplication() {
     }
     else {
         # Do not overwrite, append to existing urls
+        # Updating app fails if trying to add duplicate urls
         $existingUrls = $app.ReplyUrls
         foreach($replyUrl in $replyUrls.name) {
             $existingUrls.Add($replyUrl)
         }
+        $existingUrls = $existingUrls | Select-Object -Unique
         Set-AzureADApplication -ObjectId $app.ObjectId -RequiredResourceAccess $permission -Oauth2AllowImplicitFlow $true -ReplyUrls $existingUrls -AvailableToOtherTenants $isMultiTenant -GroupMembershipClaims $groupMembershipClaims
     }
 

--- a/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
@@ -115,7 +115,7 @@ function Remove-AzureADClientSecret {
     $deleteSecrets = $false
     [int]$retryCount = 0
 
-    if ($filterKeys.count -gt 0) {
+    if ($filteredKeys.count -gt 0) {
         $deleteSecrets = Get-InstallIdPSSUtilsUserConfirmation
     }
 

--- a/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
@@ -92,7 +92,12 @@ function New-FabricAzureADApplication() {
         $app = New-AzureADApplication -Oauth2AllowImplicitFlow $true -RequiredResourceAccess $permission -DisplayName $appName -ReplyUrls $replyUrls.name -AvailableToOtherTenants $isMultiTenant -GroupMembershipClaims $groupMembershipClaims
     }
     else {
-        Set-AzureADApplication -ObjectId $app.ObjectId -RequiredResourceAccess $permission -Oauth2AllowImplicitFlow $true -ReplyUrls $replyUrls.name -AvailableToOtherTenants $isMultiTenant -GroupMembershipClaims $groupMembershipClaims
+        # Do not overwrite, append to existing urls
+        $existingUrls = $app.ReplyUrls
+        foreach($replyUrl in $replyUrls.name) {
+            $existingUrls.Add($replyUrl)
+        }
+        Set-AzureADApplication -ObjectId $app.ObjectId -RequiredResourceAccess $permission -Oauth2AllowImplicitFlow $true -ReplyUrls $existingUrls -AvailableToOtherTenants $isMultiTenant -GroupMembershipClaims $groupMembershipClaims
     }
 
     return $app

--- a/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-IdPSS-Utilities.psm1
@@ -245,7 +245,7 @@ function Register-Identity {
         [string] $installConfigPath
     )
     $installSettings = Get-InstallationSettings $configSection -installConfigPath $installConfigPath
-    $secretName = $installSettings.azureIdentitySecretName
+    $secretName = $installSettings.azureSecretName
     Confirm-InstallIdpSSUtilsSecretName -secretName $secretName
 
     $allowedTenantsText = "allowedTenants"
@@ -299,7 +299,7 @@ function Register-IdPSS {
         [string] $installConfigPath
     )
     $installSettings = Get-InstallationSettings $configSection -installConfigPath $installConfigPath
-    $secretName = $installSettings.azureIdentitySecretName
+    $secretName = $installSettings.azureSecretName
     Confirm-InstallIdpSSUtilsSecretName -secretName $secretName
 
     # IdentityProviderSearchService registration

--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -19,7 +19,7 @@ Import-Module -Name $fabricInstallUtilities -Force
 # Import CatalystDosIdentity
 $minDosIdentityVersion = [System.Version]::new(1, 4, 18200 , 12)
 try{
-    Get-InstalledModule -Name DosInstallUtilities -MinimumVersion $minDosIdentityVersion -ErrorAction Stop
+    Get-InstalledModule -Name CatalystDosIdentity -MinimumVersion $minDosIdentityVersion -ErrorAction Stop
 } catch{
     Write-Host "Installing CatalystDosIdentity from Powershell Gallery"
     Install-Module CatalystDosIdentity -Scope CurrentUser -MinimumVersion $minDosIdentityVersion -Force

--- a/Fabric.Identity.API/scripts/install.config
+++ b/Fabric.Identity.API/scripts/install.config
@@ -70,6 +70,8 @@
       <allowedTenants>
         <variable name="" alias="" />
       </allowedTenants>
+      <!-- The name of the secret to be created for the azure application registration -->
+      <variable name="azureIdentitySecretName" value="">
     </scope>
     <scope name="identityProviderSearchService">
       <!-- The name of the app that will be created in IIS -->

--- a/Fabric.Identity.API/scripts/install.config
+++ b/Fabric.Identity.API/scripts/install.config
@@ -71,7 +71,7 @@
         <variable name="" alias="" />
       </allowedTenants>
       <!-- The name of the secret to be created for the azure application registration -->
-      <variable name="azureIdentitySecretName" value="" />
+      <variable name="azureSecretName" value="" />
     </scope>
     <scope name="identityProviderSearchService">
       <!-- The name of the app that will be created in IIS -->

--- a/Fabric.Identity.API/scripts/install.config
+++ b/Fabric.Identity.API/scripts/install.config
@@ -71,7 +71,7 @@
         <variable name="" alias="" />
       </allowedTenants>
       <!-- The name of the secret to be created for the azure application registration -->
-      <variable name="azureIdentitySecretName" value="">
+      <variable name="azureIdentitySecretName" value="" />
     </scope>
     <scope name="identityProviderSearchService">
       <!-- The name of the app that will be created in IIS -->


### PR DESCRIPTION
Update scripts to handle multiple registrations

Append to registered application ReplyUrls instead of replacing.
Require a secret name through install config to identify the secret in the registration
Prompt for secrets to be deleted if duplicate names are found


Still needs to be tested