### PR TITLE
removed validation from install-discovery script

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Discovery.ps1
+++ b/Fabric.Identity.API/scripts/Install-Discovery.ps1
@@ -3,7 +3,12 @@
     [Hashtable] $configStore = @{Type = "File"; Format = "XML"; Path = "$PSScriptRoot\install.config"},
     [switch] $quiet
 )
-
+if (!(Test-Path $configStore.Path)) {
+    throw "Path $($configStore.Path) does not exist. Please enter valid path to the install.config."
+}
+if (!(Test-Path $configStore.Path -PathType Leaf)) {
+    throw "Path $($configStore.Path) is not a file. Please enter a valid path to the install.config."
+}
 Import-Module -Name .\Install-Identity-Utilities.psm1 -Force
 
 Write-DosMessage -Level "Information" -Message "Starting DiscoveryService installation..."

--- a/Fabric.Identity.API/scripts/Install-Identity.ps1
+++ b/Fabric.Identity.API/scripts/Install-Identity.ps1
@@ -4,19 +4,16 @@
 
 param(
     [PSCredential] $credential,
-    [ValidateScript({
-        if (!(Test-Path $_)) {
-            throw "Path $_ does not exist. Please enter valid path to the install.config."
-        }
-        if (!(Test-Path $_ -PathType Leaf)) {
-            throw "Path $_ is not a file. Please enter a valid path to the install.config."
-        }
-        return $true
-    })] 
     [Hashtable] $configStore = @{Type = "File"; Format = "XML"; Path = "$PSScriptRoot\install.config"},
     [switch] $noDiscoveryService,
     [switch] $quiet
 )
+if (!(Test-Path $configStore.Path)) {
+    throw "Path $($configStore.Path) does not exist. Please enter valid path to the install.config."
+}
+if (!(Test-Path $configStore.Path -PathType Leaf)) {
+    throw "Path $($configStore.Path) is not a file. Please enter a valid path to the install.config."
+}
 Import-Module -Name .\Install-Identity-Utilities.psm1 -Force
 
 # Import Fabric Install Utilities

--- a/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
+++ b/Fabric.Identity.API/scripts/Install-IdentityProviderSearchService.ps1
@@ -4,7 +4,12 @@
     [switch] $noDiscoveryService, 
     [switch] $quiet
 )
-
+if (!(Test-Path $configStore.Path)) {
+    throw "Path $($configStore.Path) does not exist. Please enter valid path to the install.config."
+}
+if (!(Test-Path $configStore.Path -PathType Leaf)) {
+    throw "Path $($configStore.Path) is not a file. Please enter a valid path to the install.config."
+}
 Import-Module -Name .\Install-Identity-Utilities.psm1 -Force
 
 # Import Fabric Install Utilities


### PR DESCRIPTION
Weird bug.  If you call this individually, then it validates the hashtable.

If you call it from the main script, it works with no validation.