### PR TITLE
Update Install-Identity-Utilities.psm1

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -81,9 +81,9 @@ function Get-IISWebSiteForInstall([string] $selectedSiteName, [string] $installC
                         'Id'=$_.id;
                         'Name'=$_.name;
                         'Physical Path'=[System.Environment]::ExpandEnvironmentVariables($_.physicalPath);
-                        'Bindings'=$_.bindings;
+                        'Bindings'=$_.bindings.Collection;
                     };} |
-                    Format-Table Id,Name,'Physical Path',Bindings -AutoSize | Out-Host
+                    Format-Table Id,Name,'Physical Path',Bindings -AutoSize -Wrap | Out-Host
                 
                 $attempts = 1
                 do {


### PR DESCRIPTION
Had bindings by calling the Collection function on it and then wrapped the bindings when beings displayed as it was being cut off.