### PR TITLE
Update Identity Install Utilities to check OS version for cert creation

### DIFF
--- a/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
+++ b/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1
@@ -2083,15 +2083,28 @@ function New-IdentityEncryptionCertificate {
         [string] $certStoreLocation = "Cert:\LocalMachine\My",
         [string] $friendlyName = "Fabric Identity Signing Encryption Certificate"
     )
-    $cert = New-SelfSignedCertificate `
-        -Type Custom `
-        -KeySpec None `
-        -Subject $subject `
-        -KeyUsage DataEncipherment `
-        -KeyAlgorithm RSA `
-        -KeyLength 2048 `
-        -CertStoreLocation $certStoreLocation `
-        -FriendlyName $friendlyName
+
+    $OSVersion = (get-itemproperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name ProductName).ProductName
+    If($OSVersion -match "Windows Server 2012")
+    {
+        $cert = New-SelfSignedCertificate `
+            -DnsName $subject `
+            -CertStoreLocation $certStoreLocation 
+
+        $cert.FriendlyName = $friendlyName
+    }
+    Else
+    {
+        $cert = New-SelfSignedCertificate `
+            -Type Custom `
+            -KeySpec None `
+            -Subject $subject `
+            -KeyUsage DataEncipherment `
+            -KeyAlgorithm RSA `
+            -KeyLength 2048 `
+            -CertStoreLocation $certStoreLocation `
+            -FriendlyName $friendlyName
+    }
 
     return $cert
 }


### PR DESCRIPTION
* Update Install-Identity-Utilities.New-IdentityEncryptionCerfificat() to check the OS version and call the correct version of New-SelfSignedCertificate, since the method signatures are different for Windows Server 2012 and 2016.

* All parameter values included in the 2016 version call seem to be default on the 2012 call, with the friendly name as an exception. This is set after the cert is created

*DnsName creates the subject in the 2012 version