### PR TITLE
Adding a cookie policy to update to default cookie attributes for Identity

### DIFF
--- a/Fabric.Identity.API/Startup.cs
+++ b/Fabric.Identity.API/Startup.cs
@@ -259,6 +259,12 @@ namespace Fabric.Identity.API
 
             app.UseSerilogRequestLogging();
 
+            app.UseCookiePolicy(new CookiePolicyOptions()
+            {
+                MinimumSameSitePolicy = SameSiteMode.None,
+                Secure = CookieSecurePolicy.Always,
+            });
+
             app.UseAuthentication();
             app.UseIdentityServer();
 


### PR DESCRIPTION
Adding a cookie policy to update to default cookies that IdentityServer4 creates behind the scenes in middleware. Setting SameSite=None and Secure attribute to fix cross site errors with OpenId with future chrome update. See work item 194264 in Azure DevOps for more details about the issues with chrome 80.