### PR TITLE
User/tyler/chrome80 cookie update

### DIFF
--- a/Fabric.Identity.API/Startup.cs
+++ b/Fabric.Identity.API/Startup.cs
@@ -21,6 +21,7 @@ using Fabric.Platform.Logging;
 using IdentityServer4.AccessTokenValidation;
 using IdentityServer4.Quickstart.UI;
 using IdentityServer4.Services;
+using IdentityServer4;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
@@ -155,19 +156,30 @@ namespace Fabric.Identity.API
 
             services.Configure<CookiePolicyOptions>(options =>
             {
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-                options.Secure = CookieSecurePolicy.Always;
-
                 options.OnAppendCookie = cookie =>
                 {
-                    cookie.CookieOptions.SameSite = SameSiteMode.None;
-                    cookie.CookieOptions.Secure = true;
+                    var isIdentityServerCookie = cookie.CookieName.Equals(IdentityServerConstants.DefaultCheckSessionCookieName) 
+                        || cookie.CookieName.Equals(IdentityServerConstants.DefaultCookieAuthenticationScheme)
+                        || cookie.CookieName.Equals(IdentityServerConstants.ExternalCookieAuthenticationScheme);
+
+                    if (isIdentityServerCookie)
+                    {
+                        cookie.CookieOptions.SameSite = SameSiteMode.None;
+                        cookie.CookieOptions.Secure = true;
+                    }
                 };
 
                 options.OnDeleteCookie = cookie =>
                 {
-                    cookie.CookieOptions.SameSite = SameSiteMode.None;
-                    cookie.CookieOptions.Secure = true;
+                    var isIdentityServerCookie = cookie.CookieName.Equals(IdentityServerConstants.DefaultCheckSessionCookieName)
+                        || cookie.CookieName.Equals(IdentityServerConstants.DefaultCookieAuthenticationScheme)
+                        || cookie.CookieName.Equals(IdentityServerConstants.ExternalCookieAuthenticationScheme);
+
+                    if (isIdentityServerCookie)
+                    {
+                        cookie.CookieOptions.SameSite = SameSiteMode.None;
+                        cookie.CookieOptions.Secure = true;
+                    }
                 };
             });
 

--- a/Fabric.Identity.API/Startup.cs
+++ b/Fabric.Identity.API/Startup.cs
@@ -153,6 +153,24 @@ namespace Fabric.Identity.API
             services.AddTransient<IIdentityProviderConfigurationService, IdentityProviderConfigurationService>();
             services.AddTransient<AccountService>();
 
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.Secure = CookieSecurePolicy.Always;
+
+                options.OnAppendCookie = cookie =>
+                {
+                    cookie.CookieOptions.SameSite = SameSiteMode.None;
+                    cookie.CookieOptions.Secure = true;
+                };
+
+                options.OnDeleteCookie = cookie =>
+                {
+                    cookie.CookieOptions.SameSite = SameSiteMode.None;
+                    cookie.CookieOptions.Secure = true;
+                };
+            });
+
             services.AddMvc(options => { options.Conventions.Add(new CommaSeparatedQueryStringConvention()); })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
                 .AddJsonOptions(x =>
@@ -259,12 +277,7 @@ namespace Fabric.Identity.API
 
             app.UseSerilogRequestLogging();
 
-            app.UseCookiePolicy(new CookiePolicyOptions()
-            {
-                MinimumSameSitePolicy = SameSiteMode.None,
-                Secure = CookieSecurePolicy.Always,
-            });
-
+            app.UseCookiePolicy();
             app.UseAuthentication();
             app.UseIdentityServer();
 


### PR DESCRIPTION
Refactoring to set SameSite each time a cookie is appended to request, instead of setting a policy. According to microsoft, the CookiePolicyOptions.MinimumSameSitePolicy can be overwritten by middleware and isn't a guarantee that this will be set. Using OnAppendCookie sets the SameSite attribute everytime a cookie is sent and gives more granular control over cookies. See: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/

This seems to be a better way of doing it. 